### PR TITLE
Rename output to json

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-output "container_definitions" {
+output "json" {
   description = "JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition."
 
   # The following hack is required to overcome TF automatic type conversions which lead to issues with the resulting json types.


### PR DESCRIPTION
## what
Rename the output to `json`.

## why
This feels more natural when passing the output to a parameter, for example:
```
container_definitions = "${module.container_definition.json}"
```

vs the old way:
```
container_definitions = "${module.container_definition.container_definitions}"
```