### PR TITLE
Fix travis yml structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ addons:
       - make
       - curl
 
-    install:
-      - make init
+install:
+  - make init
 
-    script:
-      - make terraform/install
-      - make terraform/get-plugins
-      - make terraform/get-modules
-      - make terraform/lint
-      - make terraform/validate
+script:
+  - make terraform/install
+  - make terraform/get-plugins
+  - make terraform/get-modules
+  - make terraform/lint
+  - make terraform/validate


### PR DESCRIPTION
## what
Fix yaml structure in `.travis.yml`.

## why
Travis CI builds are failing due to `.travis.yml` being ignored.