### PR TITLE
Adjust output regexp to preserve string type of environment values

### DIFF
--- a/examples/multi_type_env_vars/main.tf
+++ b/examples/multi_type_env_vars/main.tf
@@ -1,0 +1,29 @@
+module "container" {
+  source          = "../../"
+  container_name  = "name"
+  container_image = "cloudposse/geodesic"
+
+  environment = [
+    {
+      name  = "string_var"
+      value = "I am a string"
+    },
+    {
+      name  = "true_boolean_var"
+      value = true
+    },
+    {
+      name  = "false_boolean_var"
+      value = false
+    },
+    {
+      name  = "integer_var"
+      value = 42
+    },
+  ]
+}
+
+output "json" {
+  description = "Container definition in JSON format"
+  value       = "${module.container.json}"
+}

--- a/examples/string_env_vars/main.tf
+++ b/examples/string_env_vars/main.tf
@@ -1,0 +1,25 @@
+module "container" {
+  source          = "../../"
+  container_name  = "name"
+  container_image = "cloudposse/geodesic"
+
+  environment = [
+    {
+      name  = "string_var"
+      value = "123"
+    },
+    {
+      name  = "another_string_var"
+      value = "true"
+    },
+    {
+      name  = "yet_another_string_var"
+      value = "false"
+    },
+  ]
+}
+
+output "json" {
+  description = "Container definition in JSON format"
+  value       = "${module.container.json}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,6 @@ output "json" {
   # The following hack is required to overcome TF automatic type conversions which lead to issues with the resulting json types.
   # Conversion happens by using the built-in `replace` function in this order:
   #  - Convert `""`, `{}`, `[]`, and `[""]` to `null`
-  #  - Convert `"true"` and `"false"` to `true` and `false`
-  #  - Convert quoted numbers (e.g. `"123"`) to `123`.
-  value = "${replace(replace(replace(jsonencode(local.container_definitions), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"([0-9]+\\.?[0-9]*)\"/", "$1")}"
+  #  - Remove quotes from quoted numbers (e.g. `"123"`), `"true"` and `"false"`, except inside the environment's "value" key
+  value = "${replace(replace(jsonencode(local.container_definitions), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/(\"[^v][[:alpha:]]+\":)\"([0-9]+\\.?[0-9]*|true|false)\"/", "$1$2")}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,6 +4,8 @@ output "json" {
   # The following hack is required to overcome TF automatic type conversions which lead to issues with the resulting json types.
   # Conversion happens by using the built-in `replace` function in this order:
   #  - Convert `""`, `{}`, `[]`, and `[""]` to `null`
-  #  - Remove quotes from quoted numbers (e.g. `"123"`), `"true"` and `"false"`, except inside the environment's "value" key
+  #  - Convert `"true"` and `"false"` to `true` and `false`
+  #  - Convert quoted numbers (e.g. `"123"`) to `123`.
+  # Environment variables are kept as strings.
   value = "${replace(replace(jsonencode(local.container_definitions), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/(\"[^v][[:alpha:]]+\":)\"([0-9]+\\.?[0-9]*|true|false)\"/", "$1$2")}"
 }


### PR DESCRIPTION
## what

Adjust the regexp used to overcome Terraform's type conversions for integer and boolean parameters in the JSON container definition.
The new regexp preservers the string type for environment variables.

## why

Right now, this module output does not work as input for ECS task definitions if the environment variables passed as argument include integers or booleans. This is due to the regexp in the output , transforming this type of values from strings into their original types. 

However, the `value` of environment variables in the container definition must be strings, according to AWS docs: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_environment

_Might_ be related to this issue? [#6](https://github.com/cloudposse/terraform-aws-ecs-container-definition/issues/6)