### PR TITLE
Allow for multiple port mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ This module is meant to be used as output only, meaning it will be used to creat
 ```
 Available targets:
 
-  help                                This help screen
+  help                                Help screen
   help/all                            Display help for all targets
+  help/short                          This help short screen
   lint                                Lint terraform code
 
 ```
@@ -55,15 +56,13 @@ Available targets:
 | container_memory | The amount of memory (in MiB) to allow the container to use. This is a hard limit, if the container attempts to exceed the container_memory, the container is killed. This field is optional for Fargate launch type and the total amount of container_memory of all containers in a task will need to be lower than the task memory value. | string | `256` | no |
 | container_memory_reservation | The amount of memory (in MiB) to reserve for the container. If container needs to exceed this threshold, it can do so up to the set container_memory hard limit. | string | `128` | no |
 | container_name | The name of the container. Up to 255 characters ([a-z], [A-Z], [0-9], -, _ allowed). | string | - | yes |
-| container_port | The port number on the container bound to assigned host_port. | string | `80` | no |
 | entrypoint | The entry point that is passed to the container. | string | `<list>` | no |
 | environment | The environment variables to pas to the container. This is a list of maps. | string | `<list>` | no |
 | essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value. | string | `true` | no |
 | healthcheck | A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | string | `<map>` | no |
-| host_port | The port number on the container instance (host) to reserve for the container_port. If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort. | string | `80` | no |
 | log_driver | The log driver to use for the container. If using Fargate launch type, only supported value is awslogs. | string | `awslogs` | no |
 | log_options | The configuration options to send to the log_driver. | string | `<map>` | no |
-| protocol | The protocol used for the port mapping. Options: tcp or udp. | string | `tcp` | no |
+| port_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "container_port", "host_port", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the host_port can either be left blank or set to the same value as the container_port. | string | `<list>` | no |
 | readonly_root_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value. | string | `false` | no |
 | working_directory | The working directory to run commands inside the container. | string | `` | no |
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Available targets:
 | healthcheck | A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | string | `<map>` | no |
 | log_driver | The log driver to use for the container. If using Fargate launch type, only supported value is awslogs. | string | `awslogs` | no |
 | log_options | The configuration options to send to the log_driver. | string | `<map>` | no |
-| port_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "container_port", "host_port", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the host_port can either be left blank or set to the same value as the container_port. | string | `<list>` | no |
+| port_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort. | string | `<list>` | no |
 | readonly_root_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value. | string | `false` | no |
 | working_directory | The working directory to run commands inside the container. | string | `` | no |
 

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -2,8 +2,9 @@
 ```
 Available targets:
 
-  help                                This help screen
+  help                                Help screen
   help/all                            Display help for all targets
+  help/short                          This help short screen
   lint                                Lint terraform code
 
 ```

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,15 +9,13 @@
 | container_memory | The amount of memory (in MiB) to allow the container to use. This is a hard limit, if the container attempts to exceed the container_memory, the container is killed. This field is optional for Fargate launch type and the total amount of container_memory of all containers in a task will need to be lower than the task memory value. | string | `256` | no |
 | container_memory_reservation | The amount of memory (in MiB) to reserve for the container. If container needs to exceed this threshold, it can do so up to the set container_memory hard limit. | string | `128` | no |
 | container_name | The name of the container. Up to 255 characters ([a-z], [A-Z], [0-9], -, _ allowed). | string | - | yes |
-| container_port | The port number on the container bound to assigned host_port. | string | `80` | no |
 | entrypoint | The entry point that is passed to the container. | string | `<list>` | no |
 | environment | The environment variables to pas to the container. This is a list of maps. | string | `<list>` | no |
 | essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value. | string | `true` | no |
 | healthcheck | A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | string | `<map>` | no |
-| host_port | The port number on the container instance (host) to reserve for the container_port. If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort. | string | `80` | no |
 | log_driver | The log driver to use for the container. If using Fargate launch type, only supported value is awslogs. | string | `awslogs` | no |
 | log_options | The configuration options to send to the log_driver. | string | `<map>` | no |
-| protocol | The protocol used for the port mapping. Options: tcp or udp. | string | `tcp` | no |
+| port_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "container_port", "host_port", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the host_port can either be left blank or set to the same value as the container_port. | string | `<list>` | no |
 | readonly_root_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value. | string | `false` | no |
 | working_directory | The working directory to run commands inside the container. | string | `` | no |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -15,7 +15,7 @@
 | healthcheck | A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | string | `<map>` | no |
 | log_driver | The log driver to use for the container. If using Fargate launch type, only supported value is awslogs. | string | `awslogs` | no |
 | log_options | The configuration options to send to the log_driver. | string | `<map>` | no |
-| port_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "container_port", "host_port", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the host_port can either be left blank or set to the same value as the container_port. | string | `<list>` | no |
+| port_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort. | string | `<list>` | no |
 | readonly_root_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value. | string | `false` | no |
 | working_directory | The working directory to run commands inside the container. | string | `` | no |
 

--- a/examples/multi_port_mappings/main.tf
+++ b/examples/multi_port_mappings/main.tf
@@ -24,13 +24,13 @@ module "container" {
 
   port_mappings = [
     {
-      container_port = 8080
-      host_port = 80
+      containerPort = 8080
+      hostPort = 80
       protocol = "tcp"
     },
     {
-      container_port = 8081
-      host_port = 443
+      containerPort = 8081
+      hostPort = 443
       protocol = "udp"
     },
   ]

--- a/examples/multi_port_mappings/main.tf
+++ b/examples/multi_port_mappings/main.tf
@@ -1,0 +1,42 @@
+module "container" {
+  source          = "../../"
+  container_name  = "name"
+  container_image = "cloudposse/geodesic"
+
+  environment = [
+    {
+      name  = "string_var"
+      value = "I am a string"
+    },
+    {
+      name  = "true_boolean_var"
+      value = true
+    },
+    {
+      name  = "false_boolean_var"
+      value = false
+    },
+    {
+      name  = "integer_var"
+      value = 42
+    },
+  ]
+
+  port_mappings = [
+    {
+      container_port = 8080
+      host_port = 80
+      protocol = "tcp"
+    },
+    {
+      container_port = 8081
+      host_port = 443
+      protocol = "udp"
+    },
+  ]
+}
+
+output "json" {
+  description = "Container definition in JSON format"
+  value       = "${module.container.json}"
+}

--- a/examples/multi_port_mappings/main.tf
+++ b/examples/multi_port_mappings/main.tf
@@ -25,13 +25,13 @@ module "container" {
   port_mappings = [
     {
       containerPort = 8080
-      hostPort = 80
-      protocol = "tcp"
+      hostPort      = 80
+      protocol      = "tcp"
     },
     {
       containerPort = 8081
-      hostPort = 443
-      protocol = "udp"
+      hostPort      = 443
+      protocol      = "udp"
     },
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -23,5 +23,6 @@ locals {
 
     environment = "environment_sentinel_value"
   }]
+
   environment = "${var.environment}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,4 @@
+# Environment variables are composed into the container definition at output generation time. See outputs.tf for more information.
 locals {
   container_definitions = [{
     name                   = "${var.container_name}"
@@ -11,15 +12,7 @@ locals {
     workingDirectory       = "${var.working_directory}"
     readonlyRootFilesystem = "${var.readonly_root_filesystem}"
 
-    environment = "${var.environment}"
-
-    portMappings = [
-      {
-        containerPort = "${var.container_port}"
-        hostPort      = "${var.host_port}"
-        protocol      = "${var.protocol}"
-      },
-    ]
+    portMappings = "${var.port_mappings}"
 
     healthCheck = "${var.healthcheck}"
 
@@ -27,5 +20,8 @@ locals {
       logDriver = "${var.log_driver}"
       options   = "${var.log_options}"
     }
+
+    environment = "environment_sentinel_value"
   }]
+  environment = "${var.environment}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,16 @@
+# The following hacks are required to overcome TF automatic type conversions which lead to issues with the resulting json types.
+# Conversion happens by using the built-in `replace` function in this order:
+#  - Convert `""`, `{}`, `[]`, and `[""]` to `null`
+#  - Convert `"true"` and `"false"` to `true` and `false`
+#  - Convert quoted numbers (e.g. `"123"`) to `123`.
+# Environment variables are kept as strings.
+locals {
+  encoded_container_definitions = "${replace(replace(replace(jsonencode(local.container_definitions), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"([0-9]+\\.?[0-9]*)\"/", "$1")}"
+  encoded_environment_variables = "${jsonencode(local.environment)}"
+}
+
 output "json" {
   description = "JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition."
 
-  # The following hack is required to overcome TF automatic type conversions which lead to issues with the resulting json types.
-  # Conversion happens by using the built-in `replace` function in this order:
-  #  - Convert `""`, `{}`, `[]`, and `[""]` to `null`
-  #  - Convert `"true"` and `"false"` to `true` and `false`
-  #  - Convert quoted numbers (e.g. `"123"`) to `123`.
-  # Environment variables are kept as strings.
-  value = "${replace(replace(jsonencode(local.container_definitions), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/(\"[^v][[:alpha:]]+\":)\"([0-9]+\\.?[0-9]*|true|false)\"/", "$1$2")}"
+  value = "${replace(local.encoded_container_definitions, "/\"environment_sentinel_value\"/", local.encoded_environment_variables)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,10 +17,10 @@ variable "container_memory_reservation" {
 }
 
 variable "port_mappings" {
-  description = "The port mappings to configure for the container. This is a list of maps. Each map should contain \"container_port\", \"host_port\", and \"protocol\", where \"protocol\" is one of \"tcp\" or \"udp\". If using containers in a task with the awsvpc or host network mode, the host_port can either be left blank or set to the same value as the container_port."
+  description = "The port mappings to configure for the container. This is a list of maps. Each map should contain \"containerPort\", \"hostPort\", and \"protocol\", where \"protocol\" is one of \"tcp\" or \"udp\". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort."
   default     = [{
-    "container_port" = 80
-    "host_port" = 80
+    "containerPort" = 80
+    "hostPort" = 80
     "protocol" = "tcp"
   }]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,10 +18,11 @@ variable "container_memory_reservation" {
 
 variable "port_mappings" {
   description = "The port mappings to configure for the container. This is a list of maps. Each map should contain \"containerPort\", \"hostPort\", and \"protocol\", where \"protocol\" is one of \"tcp\" or \"udp\". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort."
-  default     = [{
+
+  default = [{
     "containerPort" = 80
-    "hostPort" = 80
-    "protocol" = "tcp"
+    "hostPort"      = 80
+    "protocol"      = "tcp"
   }]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,19 +16,13 @@ variable "container_memory_reservation" {
   default     = 128
 }
 
-variable "container_port" {
-  description = "The port number on the container bound to assigned host_port."
-  default     = 80
-}
-
-variable "host_port" {
-  description = "The port number on the container instance (host) to reserve for the container_port. If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort."
-  default     = 80
-}
-
-variable "protocol" {
-  description = "The protocol used for the port mapping. Options: tcp or udp."
-  default     = "tcp"
+variable "port_mappings" {
+  description = "The port mappings to configure for the container. This is a list of maps. Each map should contain \"container_port\", \"host_port\", and \"protocol\", where \"protocol\" is one of \"tcp\" or \"udp\". If using containers in a task with the awsvpc or host network mode, the host_port can either be left blank or set to the same value as the container_port."
+  default     = [{
+    "container_port" = 80
+    "host_port" = 80
+    "protocol" = "tcp"
+  }]
 }
 
 variable "healthcheck" {


### PR DESCRIPTION
# what

Add the ability to map multiple ports.

# why

Mapping multiple ports was not possible today.

Other things to note:

1. This is a breaking change, as it does away with the individual "container_port", "host_port", and "protocol" configuration in favor of providing the entire "port_mappings" list of maps. 
1. This PR changes how environment variables get processed. They are now processed separately and replaced as the last step of output processing. This was done because the current solution was turning the ports into strings, which is invalid configuration for ECS. This effectively rolls back #9 and implements that solution in a new way that is compatible with the port mappings.