### PR TITLE
Supporting multiple definitions

### DIFF
--- a/examples/multiple_definitions/main.tf
+++ b/examples/multiple_definitions/main.tf
@@ -1,0 +1,47 @@
+module "first_container" {
+  source          = "../../"
+  container_name  = "name"
+  container_image = "cloudposse/geodesic"
+
+  port_mappings = [
+    {
+      containerPort = 8080
+      hostPort      = 80
+      protocol      = "tcp"
+    },
+    {
+      containerPort = 8081
+      hostPort      = 443
+      protocol      = "udp"
+    },
+  ]
+}
+
+module "second_container" {
+  source          = "../../"
+  container_name  = "name2"
+  container_image = "cloudposse/geodesic"
+
+  port_mappings = [
+    {
+      containerPort = 8080
+      hostPort      = 8080
+      protocol      = "tcp"
+    },
+    {
+      containerPort = 8081
+      hostPort      = 444
+      protocol      = "udp"
+    },
+  ]
+}
+
+output "json" {
+  description = "Container definition in JSON format"
+  value       = "${module.container.json}"
+}
+
+resource "aws_ecs_task_definition" "task" {
+  family                = "foo"
+  container_definitions = "[${module.first_container.json_map},${module.second_container.json_map}]"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 # Environment variables are composed into the container definition at output generation time. See outputs.tf for more information.
 locals {
-  container_definitions = [{
+  container_definition = {
     name                   = "${var.container_name}"
     image                  = "${var.container_image}"
     memory                 = "${var.container_memory}"
@@ -22,7 +22,7 @@ locals {
     }
 
     environment = "environment_sentinel_value"
-  }]
+  }
 
   environment = "${var.environment}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,18 +5,19 @@
 #  - Convert quoted numbers (e.g. `"123"`) to `123`.
 # Environment variables are kept as strings.
 locals {
-  encoded_container_definition  = "${replace(replace(replace(jsonencode(local.container_definition), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"([0-9]+\\.?[0-9]*)\"/", "$1")}"
   encoded_environment_variables = "${jsonencode(local.environment)}"
+  encoded_container_definition  = "${replace(replace(replace(jsonencode(local.container_definition), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"([0-9]+\\.?[0-9]*)\"/", "$1")}"
+  json_map                      = "${replace(local.encoded_container_definition, "/\"environment_sentinel_value\"/", local.encoded_environment_variables)}"
 }
 
 output "json" {
   description = "JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition."
 
-  value = "[${replace(local.encoded_container_definition, "/\"environment_sentinel_value\"/", local.encoded_environment_variables)}]"
+  value = "[${local.json_map}]"
 }
 
 output "json_map" {
   description = "JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition."
 
-  value = "${replace(local.encoded_container_definition, "/\"environment_sentinel_value\"/", local.encoded_environment_variables)}"
+  value = "${local.json_map}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,19 +5,18 @@
 #  - Convert quoted numbers (e.g. `"123"`) to `123`.
 # Environment variables are kept as strings.
 locals {
-  encoded_container_definition     = "${replace(replace(replace(jsonencode(list(local.container_definition)), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"([0-9]+\\.?[0-9]*)\"/", "$1")}"
-  encoded_container_definition_map = "${replace(replace(replace(jsonencode(local.container_definition), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"([0-9]+\\.?[0-9]*)\"/", "$1")}"
-  encoded_environment_variables    = "${jsonencode(local.environment)}"
+  encoded_container_definition  = "${replace(replace(replace(jsonencode(local.container_definition), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"([0-9]+\\.?[0-9]*)\"/", "$1")}"
+  encoded_environment_variables = "${jsonencode(local.environment)}"
 }
 
 output "json" {
   description = "JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition."
 
-  value = "${replace(local.encoded_container_definition, "/\"environment_sentinel_value\"/", local.encoded_environment_variables)}"
+  value = "[${replace(local.encoded_container_definition, "/\"environment_sentinel_value\"/", local.encoded_environment_variables)}]"
 }
 
 output "json_map" {
   description = "JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition."
 
-  value = "${replace(local.encoded_container_definition_map, "/\"environment_sentinel_value\"/", local.encoded_environment_variables)}"
+  value = "${replace(local.encoded_container_definition, "/\"environment_sentinel_value\"/", local.encoded_environment_variables)}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,12 +5,19 @@
 #  - Convert quoted numbers (e.g. `"123"`) to `123`.
 # Environment variables are kept as strings.
 locals {
-  encoded_container_definitions = "${replace(replace(replace(jsonencode(local.container_definitions), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"([0-9]+\\.?[0-9]*)\"/", "$1")}"
-  encoded_environment_variables = "${jsonencode(local.environment)}"
+  encoded_container_definition     = "${replace(replace(replace(jsonencode(list(local.container_definition)), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"([0-9]+\\.?[0-9]*)\"/", "$1")}"
+  encoded_container_definition_map = "${replace(replace(replace(jsonencode(local.container_definition), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"([0-9]+\\.?[0-9]*)\"/", "$1")}"
+  encoded_environment_variables    = "${jsonencode(local.environment)}"
 }
 
 output "json" {
   description = "JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition."
 
-  value = "${replace(local.encoded_container_definitions, "/\"environment_sentinel_value\"/", local.encoded_environment_variables)}"
+  value = "${replace(local.encoded_container_definition, "/\"environment_sentinel_value\"/", local.encoded_environment_variables)}"
+}
+
+output "json_map" {
+  description = "JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition."
+
+  value = "${replace(local.encoded_container_definition_map, "/\"environment_sentinel_value\"/", local.encoded_environment_variables)}"
 }


### PR DESCRIPTION
The usage for the module appears to be in a single container context 

```hcl
resource "aws_ecs_task_definition" "this" {
  container_definitions = "${module.container_definition.json}"
   ...
}
```

The change in this PR makes it possible to allow usage for multiple definitions, but a side effect is that the module would instead return the first definition and the list assignment would need to happen in the resource usage.

```hcl
resource "aws_ecs_task_definition" "this" {
  container_definitions = "[${module.container_definition.json},${module.container_definition2.json}]"
  ...
}
```

An alternative to this would be adding another output for something like `json_as_single_value` which wouldn't impact the usage. 

