### PR TITLE
Add secrets input

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Available targets:
 | container_memory_reservation | The amount of memory (in MiB) to reserve for the container. If container needs to exceed this threshold, it can do so up to the set container_memory hard limit | string | `128` | no |
 | container_name | The name of the container. Up to 255 characters ([a-z], [A-Z], [0-9], -, _ allowed) | string | - | yes |
 | entrypoint | The entry point that is passed to the container | list | `<list>` | no |
-| environment | The environment variables to pas to the container. This is a list of maps | list | `<list>` | no |
+| environment | The environment variables to pass to the container. This is a list of maps | list | `<list>` | no |
 | essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | string | `true` | no |
 | healthcheck | A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | map | `<map>` | no |
 | log_driver | The log driver to use for the container. If using Fargate launch type, only supported value is awslogs | string | `awslogs` | no |

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Available targets:
 | mount_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | list | `<list>` | no |
 | port_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort | list | `<list>` | no |
 | readonly_root_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | string | `false` | no |
+| secrets | The secrets to pass to the container. This is a list of maps | list | `<list>` | no |
 | working_directory | The working directory to run commands inside the container | string | `` | no |
 
 ## Outputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -10,7 +10,7 @@
 | container_memory_reservation | The amount of memory (in MiB) to reserve for the container. If container needs to exceed this threshold, it can do so up to the set container_memory hard limit | string | `128` | no |
 | container_name | The name of the container. Up to 255 characters ([a-z], [A-Z], [0-9], -, _ allowed) | string | - | yes |
 | entrypoint | The entry point that is passed to the container | list | `<list>` | no |
-| environment | The environment variables to pas to the container. This is a list of maps | list | `<list>` | no |
+| environment | The environment variables to pass to the container. This is a list of maps | list | `<list>` | no |
 | essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | string | `true` | no |
 | healthcheck | A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | map | `<map>` | no |
 | log_driver | The log driver to use for the container. If using Fargate launch type, only supported value is awslogs | string | `awslogs` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,6 +18,7 @@
 | mount_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | list | `<list>` | no |
 | port_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort | list | `<list>` | no |
 | readonly_root_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | string | `false` | no |
+| secrets | The secrets to pass to the container. This is a list of maps | list | `<list>` | no |
 | working_directory | The working directory to run commands inside the container | string | `` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,9 @@ locals {
     }
 
     environment = "environment_sentinel_value"
+    secrets     = "secrets_sentinel_value"
   }
 
   environment = "${var.environment}"
+  secrets     = "${var.secrets}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,8 +6,9 @@
 # Environment variables are kept as strings.
 locals {
   encoded_environment_variables = "${jsonencode(local.environment)}"
+  encoded_secrets               = "${jsonencode(local.secrets)}"
   encoded_container_definition  = "${replace(replace(replace(jsonencode(local.container_definition), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"([0-9]+\\.?[0-9]*)\"/", "$1")}"
-  json_map                      = "${replace(local.encoded_container_definition, "/\"environment_sentinel_value\"/", local.encoded_environment_variables)}"
+  json_map                      = "${replace(replace(local.encoded_container_definition, "/\"environment_sentinel_value\"/", local.encoded_environment_variables), "/\"secrets_sentinel_value\"/", local.encoded_secrets)}"
 }
 
 output "json" {

--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,7 @@ variable "working_directory" {
 
 variable "environment" {
   type        = "list"
-  description = "The environment variables to pas to the container. This is a list of maps"
+  description = "The environment variables to pass to the container. This is a list of maps"
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -70,6 +70,12 @@ variable "environment" {
   default     = []
 }
 
+variable "secrets" {
+  type        = "list"
+  description = "The secrets to pass to the container. This is a list of maps"
+  default     = []
+}
+
 variable "readonly_root_filesystem" {
   type        = "string"
   description = "Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value"


### PR DESCRIPTION
## what
* Add support for `secrets` field

## why
* ECS task definitions [now](https://aws.amazon.com/about-aws/whats-new/2018/11/aws-launches-secrets-support-for-amazon-elastic-container-servic/) support a `secrets` field.