### PR TITLE
Append secrets to container definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Available targets:
   lint                                Lint terraform code
 
 ```
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,4 +1,3 @@
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,6 @@ locals {
     }
 
     environment = "environment_sentinel_value"
-    secrets     = "secrets_sentinel_value"
   }
 
   environment = "${var.environment}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,7 +10,8 @@ locals {
   # append the secrets key if any are defined
   # empty lists in the container definition cause :
   # ClientException: When you are specifying container secrets, you must also specify a value for 'executionRoleArn'.
-  encoded_secrets              = "${jsonencode(local.secrets)}"
+  encoded_secrets = "${jsonencode(local.secrets)}"
+
   encoded_container_definition = "${replace(replace(replace(jsonencode(merge(local.container_definition, map("secrets", "secrets_sentinel_value"))), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"([0-9]+\\.?[0-9]*)\"/", "$1")}"
   json_map                     = "${replace(replace(local.encoded_container_definition, "/\"environment_sentinel_value\"/", local.encoded_environment_variables), "/\"secrets_sentinel_value\"/", local.encoded_secrets)}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,7 +10,7 @@ locals {
   # append the secrets key if any are defined
   # empty lists in the container definition cause 
   # ClientException: When you are specifying container secrets, you must also specify a value for 'executionRoleArn'.
-  container_definition_output = "${length(var.secrets) == 0 ? local.container_definition : merge(local.encoded_container_definition, map("secrets", "secrets_sentinel_value"))}"
+  container_definition_output = "${length(var.secrets) == 0 ? local.container_definition : merge(local.container_definition, map("secrets", "secrets_sentinel_value"))}"
 
   encoded_secrets              = "${jsonencode(local.secrets)}"
   encoded_container_definition = "${replace(replace(replace(jsonencode(local.container_definition), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"([0-9]+\\.?[0-9]*)\"/", "$1")}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,12 +8,10 @@ locals {
   encoded_environment_variables = "${jsonencode(local.environment)}"
 
   # append the secrets key if any are defined
-  # empty lists in the container definition cause 
+  # empty lists in the container definition cause :
   # ClientException: When you are specifying container secrets, you must also specify a value for 'executionRoleArn'.
-  container_definition_output = "${length(var.secrets) == 0 ? local.container_definition : merge(local.container_definition, map("secrets", "secrets_sentinel_value"))}"
-
   encoded_secrets              = "${jsonencode(local.secrets)}"
-  encoded_container_definition = "${replace(replace(replace(jsonencode(local.container_definition), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"([0-9]+\\.?[0-9]*)\"/", "$1")}"
+  encoded_container_definition = "${replace(replace(replace(jsonencode(merge(local.container_definition, map("secrets", "secrets_sentinel_value"))), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"([0-9]+\\.?[0-9]*)\"/", "$1")}"
   json_map                     = "${replace(replace(local.encoded_container_definition, "/\"environment_sentinel_value\"/", local.encoded_environment_variables), "/\"secrets_sentinel_value\"/", local.encoded_secrets)}"
 }
 


### PR DESCRIPTION
## What
Appending the secrets key to the `container_definition` if the secrets input isn't empty

## Why

When using this with `aws_ecs_task_definition` the container definition with an empty secrets key causes AWS SDK to throw an error

```
# ClientException: When you are specifying container secrets, you must also specify a value for 'executionRoleArn'.
```

maybe this is a problem further down the chain https://github.com/terraform-providers/terraform-provider-aws/issues/6503. I can't find anywhere documented that role is required for secrets

## Notes
I originally put the secret appending into another local but terraform got upset about using maps in conditional statements
```
container_definition_output = "${length(var.secrets) == 0 ? local.container_definition : merge(local.container_definition, map("secrets", "secrets_sentinel_value"))}"
```
Error:
```
local.container_definition_output: At column 3, line 1: conditional operator cannot be used with map values in:

${length(var.secrets) == 0 ? local.container_definition : local.secrets_map }`