### PR TITLE
Set secrets to null if empty list

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -6,7 +6,7 @@
 # Environment variables are kept as strings.
 locals {
   encoded_environment_variables = "${jsonencode(local.environment)}"
-  encoded_secrets               = "${jsonencode(local.secrets)}"
+  encoded_secrets               = "${length(local.secrets) > 0 ? jsonencode(local.secrets) : "null"}"
   encoded_container_definition  = "${replace(replace(replace(jsonencode(local.container_definition), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"([0-9]+\\.?[0-9]*)\"/", "$1")}"
   json_map                      = "${replace(replace(local.encoded_container_definition, "/\"environment_sentinel_value\"/", local.encoded_environment_variables), "/\"secrets_sentinel_value\"/", local.encoded_secrets)}"
 }


### PR DESCRIPTION
I've seen the following error from Terraform when no secrets are passed to terraform-aws-ecs-container-definition:

```
* aws_ecs_task_definition.task_definition: ClientException: When you are specifying container secrets, you must also specify a value for 'executionRoleArn'.
        status code: 400, request id: 8e82fc41-1039-11e9-a6c6-d14d7e4d29d9
```

It seems like AWS is only checking if secrets is not-null. This change sets secrets to `null` if it's an empty list.