### PR TITLE
add support for private repo credentials

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -18,6 +19,7 @@
 | mount_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | list | `<list>` | no |
 | port_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort | list | `<list>` | no |
 | readonly_root_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | string | `false` | no |
+| repository_secret_arn | The ARN for an AWS SecretsManager secret containing credentials for a private docker repository | string | `` | no |
 | secrets | The secrets to pass to the container. This is a list of maps | list | `<list>` | no |
 | working_directory | The working directory to run commands inside the container | string | `` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,10 @@ locals {
       options   = "${var.log_options}"
     }
 
+    repositoryCredentials = {
+      credentialsParameter = "${var.repository_secret_arn}"
+    }
+
     environment = "environment_sentinel_value"
     secrets     = "secrets_sentinel_value"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,12 @@ variable "secrets" {
   default     = []
 }
 
+variable "repository_secret_arn" {
+  type        = "string"
+  description = "The ARN for an AWS SecretsManager secret containing credentials for a private docker repository"
+  default     = ""
+}
+
 variable "readonly_root_filesystem" {
   type        = "string"
   description = "Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value"


### PR DESCRIPTION
Provide support for private repository credentials stored in the
AWS SecretsManager service.