### PR TITLE
support private repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Available targets:
 | mount_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | list | `<list>` | no |
 | port_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort | list | `<list>` | no |
 | readonly_root_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | string | `false` | no |
-| repository_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a secretsmanager secret holding the credentials. | map | `<map>` | no |
+| repository_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a Secrets Manager's secret holding the credentials | map | `<map>` | no |
 | secrets | The secrets to pass to the container. This is a list of maps | list | `<list>` | no |
 | ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | list | `<list>` | no |
 | working_directory | The working directory to run commands inside the container | string | `` | no |

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Available targets:
 | mount_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | list | `<list>` | no |
 | port_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort | list | `<list>` | no |
 | readonly_root_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | string | `false` | no |
+| repository_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a secretsmanager secret holding the credentials. | map | `<map>` | no |
 | secrets | The secrets to pass to the container. This is a list of maps | list | `<list>` | no |
 | ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | list | `<list>` | no |
 | working_directory | The working directory to run commands inside the container | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,7 +18,7 @@
 | mount_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | list | `<list>` | no |
 | port_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort | list | `<list>` | no |
 | readonly_root_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | string | `false` | no |
-| repository_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a secretsmanager secret holding the credentials. | map | `<map>` | no |
+| repository_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a Secrets Manager's secret holding the credentials | map | `<map>` | no |
 | secrets | The secrets to pass to the container. This is a list of maps | list | `<list>` | no |
 | ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | list | `<list>` | no |
 | working_directory | The working directory to run commands inside the container | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,6 +18,7 @@
 | mount_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | list | `<list>` | no |
 | port_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort | list | `<list>` | no |
 | readonly_root_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | string | `false` | no |
+| repository_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a secretsmanager secret holding the credentials. | map | `<map>` | no |
 | secrets | The secrets to pass to the container. This is a list of maps | list | `<list>` | no |
 | ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | list | `<list>` | no |
 | working_directory | The working directory to run commands inside the container | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,7 @@ locals {
     mountPoints            = "${var.mount_points}"
     dnsServers             = "${var.dns_servers}"
     ulimits                = "${var.ulimits}"
+    repositoryCredentials  = "${var.repository_credentials}"
 
     portMappings = "${var.port_mappings}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -128,6 +128,6 @@ variable "ulimits" {
 
 variable "repository_credentials" {
   type        = "map"
-  description = "Container repository credentials; required when using a private repo.  This map currently supports a single key; \"credentialsParameter\", which should be the ARN of a secretsmanager secret holding the credentials."
+  description = "Container repository credentials; required when using a private repo.  This map currently supports a single key; \"credentialsParameter\", which should be the ARN of a Secrets Manager's secret holding the credentials"
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -125,3 +125,9 @@ variable "ulimits" {
   description = "Container ulimit settings. This is a list of maps, where each map should contain \"name\", \"hardLimit\" and \"softLimit\""
   default     = []
 }
+
+variable "repository_credentials" {
+  type        = "map"
+  description = "Container repository credentials; required when using a private repo.  This map currently supports a single key; \"credentialsParameter\", which should be the ARN of a secretsmanager secret holding the credentials."
+  default     = {}
+}


### PR DESCRIPTION
* added repository_credentials, a map which corresponds to the repositoryCredentials json key.
* addresses #19