### PR TITLE
v0.12: specify parameter type as object

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,13 @@ variable "port_mappings" {
 }
 
 variable "healthcheck" {
-  type        = "map"
+  type = object({
+    command     = list(string)
+    retries     = number
+    timeout     = number
+    interval    = number
+    startPeriod = number
+  })
   description = "A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries)"
   default     = {}
 }


### PR DESCRIPTION
I addresses https://github.com/cloudposse/terraform-aws-ecs-container-definition/issues/33

Reading https://github.com/hashicorp/terraform/issues/21384 I believed we should use `object` type in this case.
It's working in our environment, with v0.12, incompatible with v0.11 though.