### PR TITLE
Renamed depends_on variable (reserved name in Terraform 0.12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Available targets:
 | container_memory | The amount of memory (in MiB) to allow the container to use. This is a hard limit, if the container attempts to exceed the container_memory, the container is killed. This field is optional for Fargate launch type and the total amount of container_memory of all containers in a task will need to be lower than the task memory value | string | `256` | no |
 | container_memory_reservation | The amount of memory (in MiB) to reserve for the container. If container needs to exceed this threshold, it can do so up to the set container_memory hard limit | string | `128` | no |
 | container_name | The name of the container. Up to 255 characters ([a-z], [A-Z], [0-9], -, _ allowed) | string | - | yes |
-| depends_on | The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed | list | `<list>` | no |
+| container_depends_on | The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed | list | `<list>` | no |
 | dns_servers | Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers. | list | `<list>` | no |
 | entrypoint | The entry point that is passed to the container | list | `<list>` | no |
 | environment | The environment variables to pass to the container. This is a list of maps | list | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ locals {
     links                  = "${var.links}"
     volumesFrom            = "${var.volumes_from}"
     user                   = "${var.user}"
-    dependsOn              = "${var.depends_on}"
+    dependsOn              = "${var.container_depends_on}"
     stopTimeout            = "stop_timeout_sentinel_value"
 
     portMappings = "${var.port_mappings}"

--- a/variables.tf
+++ b/variables.tf
@@ -149,7 +149,7 @@ variable "user" {
   default     = ""
 }
 
-variable "depends_on" {
+variable "container_depends_on" {
   type        = "list"
   description = "The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed"
   default     = []


### PR DESCRIPTION
This is required to get this module to work with Terraform 0.12