### PR TITLE
Add privileged parameter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,7 @@ locals {
     user                   = "${var.user}"
     dependsOn              = "${var.container_depends_on}"
     stopTimeout            = "stop_timeout_sentinel_value"
+    privileged             = "${var.privileged}"
 
     portMappings = "${var.port_mappings}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -159,3 +159,9 @@ variable "stop_timeout" {
   description = "Timeout in seconds between sending SIGTERM and SIGKILL to container"
   default     = 30
 }
+
+variable "privileged" {
+  type        = "string"
+  description = "When this variable is true, the container is given elevated privileges on the host container instance (similar to the root user). This parameter is not supported for Windows containers or tasks using the Fargate launch type. Due to how Terraform type casts booleans in json it is required to double quote this value"
+  default     = ""
+}


### PR DESCRIPTION
Adding the `privileged` parameter to allow containers to be given elevated privileges on the host container instance.

The default value is `""` rather than `"false"` so that it becomes `"privileged": null` in the JSON output. This is because this parameter is not supported for Windows containers or tasks using the Fargate launch type.