### PR TITLE
terraform 0.12 syntax and simplification

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -2,36 +2,35 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| command | The command that is passed to the container | list | `<list>` | no |
-| container_cpu | The number of cpu units to reserve for the container. This is optional for tasks using Fargate launch type and the total amount of container_cpu of all containers in a task will need to be lower than the task-level cpu value | string | `256` | no |
-| container_image | The image used to start the container. Images in the Docker Hub registry available by default | string | - | yes |
-| container_memory | The amount of memory (in MiB) to allow the container to use. This is a hard limit, if the container attempts to exceed the container_memory, the container is killed. This field is optional for Fargate launch type and the total amount of container_memory of all containers in a task will need to be lower than the task memory value | string | `256` | no |
-| container_memory_reservation | The amount of memory (in MiB) to reserve for the container. If container needs to exceed this threshold, it can do so up to the set container_memory hard limit | string | `128` | no |
-| container_name | The name of the container. Up to 255 characters ([a-z], [A-Z], [0-9], -, _ allowed) | string | - | yes |
-| depends_on | The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed | list | `<list>` | no |
-| dns_servers | Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers. | list | `<list>` | no |
-| entrypoint | The entry point that is passed to the container | list | `<list>` | no |
-| environment | The environment variables to pass to the container. This is a list of maps | list | `<list>` | no |
-| essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | string | `true` | no |
-| healthcheck | A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | map | `<map>` | no |
-| links | List of container names this container can communicate with without port mappings. | list | `<list>` | no |
-| log_driver | The log driver to use for the container. If using Fargate launch type, only supported value is awslogs | string | `awslogs` | no |
-| log_options | The configuration options to send to the `log_driver` | map | `<map>` | no |
-| mount_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | list | `<list>` | no |
-| port_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort | list | `<list>` | no |
-| readonly_root_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | string | `false` | no |
-| repository_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a Secrets Manager's secret holding the credentials | map | `<map>` | no |
-| secrets | The secrets to pass to the container. This is a list of maps | list | `<list>` | no |
-| stop_timeout | Timeout in seconds between sending SIGTERM and SIGKILL to container | string | `30` | no |
-| ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | list | `<list>` | no |
-| user | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group | string | `` | no |
-| volumes_from | A list of VolumesFrom maps which contain "sourceContainer" (name of the container that has the volumes to mount) and "readOnly" (whether the container can write to the volume). | list | `<list>` | no |
-| working_directory | The working directory to run commands inside the container | string | `` | no |
+| command | The command that is passed to the container | list(string) | `"null"` | no |
+| container\_cpu | The number of cpu units to reserve for the container. This is optional for tasks using Fargate launch type and the total amount of container_cpu of all containers in a task will need to be lower than the task-level cpu value | number | `"256"` | no |
+| container\_depends\_on | The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed | list(string) | `"null"` | no |
+| container\_image | The image used to start the container. Images in the Docker Hub registry available by default | string | n/a | yes |
+| container\_memory | The amount of memory (in MiB) to allow the container to use. This is a hard limit, if the container attempts to exceed the container_memory, the container is killed. This field is optional for Fargate launch type and the total amount of container_memory of all containers in a task will need to be lower than the task memory value | number | `"256"` | no |
+| container\_memory\_reservation | The amount of memory (in MiB) to reserve for the container. If container needs to exceed this threshold, it can do so up to the set container_memory hard limit | number | `"128"` | no |
+| container\_name | The name of the container. Up to 255 characters ([a-z], [A-Z], [0-9], -, _ allowed) | string | n/a | yes |
+| dns\_servers | Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers. | list(string) | `"null"` | no |
+| entrypoint | The entry point that is passed to the container | list(string) | `"null"` | no |
+| environment | The environment variables to pass to the container. This is a list of maps | list(map(string)) | `"null"` | no |
+| essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | bool | `"true"` | no |
+| healthcheck | A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | map(string) | `"null"` | no |
+| links | List of container names this container can communicate with without port mappings. | list(string) | `"null"` | no |
+| log\_driver | The log driver to use for the container. If using Fargate launch type, only supported value is awslogs | string | `"awslogs"` | no |
+| log\_options | The configuration options to send to the `log_driver` | map(string) | `{ "awslogs-group": "default", "awslogs-region": "us-west-2", "awslogs-stream-prefix": "default" }` | no |
+| mount\_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | list( | `"null"` | no |
+| port\_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort | list( | `[ { "containerPort": 80, "hostPort": 80, "protocol": "tcp" } ]` | no |
+| readonly\_root\_filesystem | Determines whether a container is given read-only access to its root filesystem. | bool | `"false"` | no |
+| repository\_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a Secrets Manager's secret holding the credentials | map(string) | `"null"` | no |
+| secrets | The secrets to pass to the container. This is a list of maps | list(string) | `"null"` | no |
+| stop\_timeout | Timeout in seconds between sending SIGTERM and SIGKILL to container | number | `"30"` | no |
+| ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | list(string) | `"null"` | no |
+| user | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group | string | `"null"` | no |
+| volumes\_from | A list of VolumesFrom maps which contain "sourceContainer" (name of the container that has the volumes to mount) and "readOnly" (whether the container can write to the volume). | list(string) | `"null"` | no |
+| working\_directory | The working directory to run commands inside the container | string | `"null"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | json | JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition. |
-| json_map | JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition. |
-
+| json\_map | JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition. |

--- a/main.tf
+++ b/main.tf
@@ -1,39 +1,32 @@
 # Environment variables are composed into the container definition at output generation time. See outputs.tf for more information.
 locals {
   container_definition = {
-    name                   = "${var.container_name}"
-    image                  = "${var.container_image}"
-    memory                 = "memory_sentinel_value"
-    memoryReservation      = "memory_reservation_sentinel_value"
-    cpu                    = "cpu_sentinel_value"
-    essential              = "${var.essential}"
-    entryPoint             = "${var.entrypoint}"
-    command                = "${var.command}"
-    workingDirectory       = "${var.working_directory}"
-    readonlyRootFilesystem = "${var.readonly_root_filesystem}"
-    mountPoints            = "${var.mount_points}"
-    dnsServers             = "${var.dns_servers}"
-    ulimits                = "${var.ulimits}"
-    repositoryCredentials  = "${var.repository_credentials}"
-    links                  = "${var.links}"
-    volumesFrom            = "${var.volumes_from}"
-    user                   = "${var.user}"
-    dependsOn              = "${var.container_depends_on}"
-    stopTimeout            = "stop_timeout_sentinel_value"
-
-    portMappings = "${var.port_mappings}"
-
-    healthCheck = "${var.healthcheck}"
-
+    name                   = var.container_name
+    image                  = var.container_image
+    memory                 = var.container_cpu > 0 ? var.container_cpu : null
+    memoryReservation      = var.container_memory_reservation > 0 ? var.container_memory_reservation : null
+    cpu                    = var.container_cpu > 0 ? var.container_cpu : null
+    essential              = var.essential
+    entryPoint             = var.entrypoint
+    command                = var.command
+    workingDirectory       = var.working_directory
+    readonlyRootFilesystem = var.readonly_root_filesystem
+    mountPoints            = var.mount_points
+    dnsServers             = var.dns_servers
+    ulimits                = var.ulimits
+    repositoryCredentials  = var.repository_credentials
+    links                  = var.links
+    volumesFrom            = var.volumes_from
+    user                   = var.user
+    dependsOn              = var.container_depends_on
+    stopTimeout            = var.stop_timeout > 0 ? var.stop_timeout : null
+    portMappings           = var.port_mappings
+    healthCheck            = var.healthcheck
     logConfiguration = {
-      logDriver = "${var.log_driver}"
-      options   = "${var.log_options}"
+      logDriver = var.log_driver
+      options   = var.log_options
     }
-
-    environment = "environment_sentinel_value"
-    secrets     = "secrets_sentinel_value"
+    environment = var.environment
+    secrets     = var.secrets
   }
-
-  environment = "${var.environment}"
-  secrets     = "${var.secrets}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,36 +1,11 @@
-# The following hacks are required to overcome TF automatic type conversions which lead to issues with the resulting json types.
-# Conversion happens by using the built-in `replace` function in this order:
-#  - Convert `""`, `{}`, `[]`, and `[""]` to `null`
-#  - Convert `"true"` and `"false"` to `true` and `false`
-#  - Convert quoted numbers (e.g. `"123"`) to `123`.
-# Environment variables are kept as strings.
-locals {
-  encoded_environment_variables = "${jsonencode(local.environment)}"
-  encoded_secrets               = "${length(local.secrets) > 0 ? jsonencode(local.secrets) : "null"}"
-  encoded_cpu                   = "${var.container_cpu > 0 ? var.container_cpu : "null"}"
-  encoded_memory                = "${var.container_memory > 0 ? var.container_memory : "null"}"
-  encoded_memory_reservation    = "${var.container_memory_reservation > 0 ? var.container_memory_reservation : "null"}"
-  encoded_stop_timeout          = "${var.stop_timeout > 0 ? var.stop_timeout : "null"}"
-  encoded_container_definition  = "${replace(replace(replace(jsonencode(local.container_definition), "/(\\[\\]|\\[\"\"\\]|\"\"|{})/", "null"), "/\"(true|false)\"/", "$1"), "/\"(-?[0-9]+\\.?[0-9]*)\"/", "$1")}"
-
-  json_with_environment        = "${replace(local.encoded_container_definition, "/\"environment_sentinel_value\"/", local.encoded_environment_variables)}"
-  json_with_secrets            = "${replace(local.json_with_environment, "/\"secrets_sentinel_value\"/", local.encoded_secrets)}"
-  json_with_cpu                = "${replace(local.json_with_secrets, "/\"cpu_sentinel_value\"/", local.encoded_cpu)}"
-  json_with_memory             = "${replace(local.json_with_cpu, "/\"memory_sentinel_value\"/", local.encoded_memory)}"
-  json_with_memory_reservation = "${replace(local.json_with_memory, "/\"memory_reservation_sentinel_value\"/", local.encoded_memory_reservation)}"
-  json_with_stop_timeout       = "${replace(local.json_with_memory_reservation, "/\"stop_timeout_sentinel_value\"/", local.encoded_stop_timeout)}"
-
-  json_map = "${local.json_with_stop_timeout}"
-}
-
 output "json" {
   description = "JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition."
 
-  value = "[${local.json_map}]"
+  value = "[${jsonencode(local.container_definition)}]"
 }
 
 output "json_map" {
   description = "JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition."
 
-  value = "${local.json_map}"
+  value = jsonencode(local.container_definition)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,111 +1,128 @@
 variable "container_name" {
-  type        = "string"
+  type        = string
   description = "The name of the container. Up to 255 characters ([a-z], [A-Z], [0-9], -, _ allowed)"
 }
 
 variable "container_image" {
-  type        = "string"
+  type        = string
   description = "The image used to start the container. Images in the Docker Hub registry available by default"
 }
 
 variable "container_memory" {
   description = "The amount of memory (in MiB) to allow the container to use. This is a hard limit, if the container attempts to exceed the container_memory, the container is killed. This field is optional for Fargate launch type and the total amount of container_memory of all containers in a task will need to be lower than the task memory value"
+  type        = number
   default     = 256
 }
 
 variable "container_memory_reservation" {
   description = "The amount of memory (in MiB) to reserve for the container. If container needs to exceed this threshold, it can do so up to the set container_memory hard limit"
+  type        = number
   default     = 128
 }
 
 variable "port_mappings" {
-  type        = "list"
+  type = list(
+    object(
+      {
+        containerPort = number
+        hostPort      = number
+        protocol      = string
+      }
+    )
+  )
   description = "The port mappings to configure for the container. This is a list of maps. Each map should contain \"containerPort\", \"hostPort\", and \"protocol\", where \"protocol\" is one of \"tcp\" or \"udp\". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort"
 
-  default = [{
-    "containerPort" = 80
-    "hostPort"      = 80
-    "protocol"      = "tcp"
-  }]
+  default = [
+    {
+      "containerPort" = 80
+      "hostPort"      = 80
+      "protocol"      = "tcp"
+    },
+  ]
 }
 
 variable "healthcheck" {
-  type        = "map"
+  type        = map(string)
   description = "A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries)"
-  default     = {}
+  default     = null
 }
 
 variable "container_cpu" {
   description = "The number of cpu units to reserve for the container. This is optional for tasks using Fargate launch type and the total amount of container_cpu of all containers in a task will need to be lower than the task-level cpu value"
+  type        = number
   default     = 256
 }
 
 variable "essential" {
-  type        = "string"
+  type        = bool
   description = "Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value"
-  default     = "true"
+  default     = true
 }
 
 variable "entrypoint" {
-  type        = "list"
+  type        = list(string)
   description = "The entry point that is passed to the container"
-  default     = [""]
+  default     = null
 }
 
 variable "command" {
-  type        = "list"
+  type        = list(string)
   description = "The command that is passed to the container"
-  default     = [""]
+  default     = null
 }
 
 variable "working_directory" {
-  type        = "string"
+  type        = string
   description = "The working directory to run commands inside the container"
-  default     = ""
+  default     = null
 }
 
 variable "environment" {
-  type        = "list"
+  type        = list(map(string))
   description = "The environment variables to pass to the container. This is a list of maps"
-  default     = []
+  default     = null
 }
 
 variable "secrets" {
-  type        = "list"
+  type        = list(string)
   description = "The secrets to pass to the container. This is a list of maps"
-  default     = []
+  default     = null
 }
 
 variable "readonly_root_filesystem" {
-  type        = "string"
-  description = "Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value"
-  default     = "false"
+  type        = bool
+  description = "Determines whether a container is given read-only access to its root filesystem."
+  default     = false
 }
 
 variable "log_driver" {
-  type        = "string"
+  type        = string
   description = "The log driver to use for the container. If using Fargate launch type, only supported value is awslogs"
   default     = "awslogs"
 }
 
 variable "log_options" {
-  type        = "map"
+  type        = map(string)
   description = "The configuration options to send to the `log_driver`"
 
   default = {
-    "awslogs-region" = "us-west-2"
-
-    "awslogs-group" = "default"
-
+    "awslogs-region"        = "us-west-2"
+    "awslogs-group"         = "default"
     "awslogs-stream-prefix" = "default"
   }
 }
 
 variable "mount_points" {
-  type        = "list"
+  type = list(
+    object(
+      {
+        containerPath = string
+        sourceVolume  = string
+      }
+    )
+  )
   description = "Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`"
-  default     = []
-
+  default     = null
   #default     = [
   #  {
   #    containerPath  = "/tmp"
@@ -115,47 +132,49 @@ variable "mount_points" {
 }
 
 variable "dns_servers" {
-  type        = "list"
+  type        = list(string)
   description = "Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers."
-  default     = []
+  default     = null
 }
 
 variable "ulimits" {
-  type        = "list"
+  type        = list(string)
   description = "Container ulimit settings. This is a list of maps, where each map should contain \"name\", \"hardLimit\" and \"softLimit\""
-  default     = []
+  default     = null
 }
 
 variable "repository_credentials" {
-  type        = "map"
+  type        = map(string)
   description = "Container repository credentials; required when using a private repo.  This map currently supports a single key; \"credentialsParameter\", which should be the ARN of a Secrets Manager's secret holding the credentials"
-  default     = {}
+  default     = null
 }
 
 variable "volumes_from" {
-  type        = "list"
+  type        = list(string)
   description = "A list of VolumesFrom maps which contain \"sourceContainer\" (name of the container that has the volumes to mount) and \"readOnly\" (whether the container can write to the volume)."
-  default     = []
+  default     = null
 }
 
 variable "links" {
-  type        = "list"
+  type        = list(string)
   description = "List of container names this container can communicate with without port mappings."
-  default     = []
+  default     = null
 }
 
 variable "user" {
   description = "The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group"
-  default     = ""
+  type        = string
+  default     = null
 }
 
 variable "container_depends_on" {
-  type        = "list"
+  type        = list(string)
   description = "The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed"
-  default     = []
+  default     = null
 }
 
 variable "stop_timeout" {
   description = "Timeout in seconds between sending SIGTERM and SIGKILL to container"
+  type        = number
   default     = 30
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Enforce proper variable types, remove the need for regex replacements of
empty values to null.