### PR TITLE
Simplify code using TF 0.12 first-class types and syntax. Sort provided ENV vars. Add missing parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,40 +79,40 @@ Available targets:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| command | The command that is passed to the container | list(string) | `<list>` | no |
+| command | The command that is passed to the container | list(string) | `null` | no |
 | container_cpu | The number of cpu units to reserve for the container. This is optional for tasks using Fargate launch type and the total amount of container_cpu of all containers in a task will need to be lower than the task-level cpu value | number | `256` | no |
-| container_depends_on | The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed | list(string) | `<list>` | no |
+| container_depends_on | The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed | list(string) | `null` | no |
 | container_image | The image used to start the container. Images in the Docker Hub registry available by default | string | - | yes |
 | container_memory | The amount of memory (in MiB) to allow the container to use. This is a hard limit, if the container attempts to exceed the container_memory, the container is killed. This field is optional for Fargate launch type and the total amount of container_memory of all containers in a task will need to be lower than the task memory value | number | `256` | no |
 | container_memory_reservation | The amount of memory (in MiB) to reserve for the container. If container needs to exceed this threshold, it can do so up to the set container_memory hard limit | number | `128` | no |
 | container_name | The name of the container. Up to 255 characters ([a-z], [A-Z], [0-9], -, _ allowed) | string | - | yes |
-| dns_servers | Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers | list(string) | `<list>` | no |
+| dns_servers | Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers | list(string) | `null` | no |
 | docker_labels | The configuration options to send to the `docker_labels` | map(string) | `null` | no |
-| entrypoint | The entry point that is passed to the container | list(string) | `<list>` | no |
-| environment | The environment variables to pass to the container. This is a list of maps | list(map(string)) | `<list>` | no |
+| entrypoint | The entry point that is passed to the container | list(string) | `null` | no |
+| environment | The environment variables to pass to the container. This is a list of maps | object | `null` | no |
 | essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | bool | `true` | no |
 | firelens_configuration | The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html | object | `null` | no |
-| healthcheck | A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | map(string) | `null` | no |
-| links | List of container names this container can communicate with without port mappings | list(string) | `<list>` | no |
+| healthcheck | A map containing command (string), timeout, interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy), and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | object | `null` | no |
+| links | List of container names this container can communicate with without port mappings | list(string) | `null` | no |
 | log_configuration | Log configuration options to send to a custom log driver for the container. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html | object | `null` | no |
-| mount_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | object | `<list>` | no |
+| mount_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | object | `null` | no |
 | port_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort | object | `<list>` | no |
-| privileged | When this variable is `true`, the container is given elevated privileges on the host container instance (similar to the root user). This parameter is not supported for Windows containers or tasks using the Fargate launch type. Due to how Terraform type casts booleans in json it is required to double quote this value | string | `` | no |
+| privileged | When this variable is `true`, the container is given elevated privileges on the host container instance (similar to the root user). This parameter is not supported for Windows containers or tasks using the Fargate launch type. Due to how Terraform type casts booleans in json it is required to double quote this value | string | `null` | no |
 | readonly_root_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | bool | `false` | no |
 | repository_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a Secrets Manager's secret holding the credentials | map(string) | `null` | no |
-| secrets | The secrets to pass to the container. This is a list of maps | list(map(string)) | `<list>` | no |
+| secrets | The secrets to pass to the container. This is a list of maps | object | `null` | no |
 | stop_timeout | Timeout in seconds between sending SIGTERM and SIGKILL to container | number | `30` | no |
-| system_controls | A list of namespaced kernel parameters to set in the container, mapping to the --sysctl option to docker run. This is a list of maps: { namespace = "", value = ""} | list(map(string)) | `<list>` | no |
-| ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | object | `<list>` | no |
-| user | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group | string | `` | no |
-| volumes_from | A list of VolumesFrom maps which contain "sourceContainer" (name of the container that has the volumes to mount) and "readOnly" (whether the container can write to the volume) | object | `<list>` | no |
-| working_directory | The working directory to run commands inside the container | string | `` | no |
+| system_controls | A list of namespaced kernel parameters to set in the container, mapping to the --sysctl option to docker run. This is a list of maps: { namespace = "", value = ""} | list(map(string)) | `null` | no |
+| ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | object | `null` | no |
+| user | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group | string | `null` | no |
+| volumes_from | A list of VolumesFrom maps which contain "sourceContainer" (name of the container that has the volumes to mount) and "readOnly" (whether the container can write to the volume) | object | `null` | no |
+| working_directory | The working directory to run commands inside the container | string | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| json | JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition |
+| json | JSON encoded list of container definitions for use with other terraform resources such as aws_ecs_task_definition |
 | json_map | JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition |
 
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ Available targets:
 | readonly_root_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | bool | `false` | no |
 | repository_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a Secrets Manager's secret holding the credentials | map(string) | `null` | no |
 | secrets | The secrets to pass to the container. This is a list of maps | object | `null` | no |
-| stop_timeout | Timeout in seconds between sending SIGTERM and SIGKILL to container | number | `30` | no |
+| start_timeout | Time duration (in seconds) to wait before giving up on resolving dependencies for a container | number | `30` | no |
+| stop_timeout | Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own | number | `30` | no |
 | system_controls | A list of namespaced kernel parameters to set in the container, mapping to the --sysctl option to docker run. This is a list of maps: { namespace = "", value = ""} | list(map(string)) | `null` | no |
 | ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | object | `null` | no |
 | user | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group | string | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -2,39 +2,39 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| command | The command that is passed to the container | list(string) | `<list>` | no |
+| command | The command that is passed to the container | list(string) | `null` | no |
 | container_cpu | The number of cpu units to reserve for the container. This is optional for tasks using Fargate launch type and the total amount of container_cpu of all containers in a task will need to be lower than the task-level cpu value | number | `256` | no |
-| container_depends_on | The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed | list(string) | `<list>` | no |
+| container_depends_on | The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed | list(string) | `null` | no |
 | container_image | The image used to start the container. Images in the Docker Hub registry available by default | string | - | yes |
 | container_memory | The amount of memory (in MiB) to allow the container to use. This is a hard limit, if the container attempts to exceed the container_memory, the container is killed. This field is optional for Fargate launch type and the total amount of container_memory of all containers in a task will need to be lower than the task memory value | number | `256` | no |
 | container_memory_reservation | The amount of memory (in MiB) to reserve for the container. If container needs to exceed this threshold, it can do so up to the set container_memory hard limit | number | `128` | no |
 | container_name | The name of the container. Up to 255 characters ([a-z], [A-Z], [0-9], -, _ allowed) | string | - | yes |
-| dns_servers | Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers | list(string) | `<list>` | no |
+| dns_servers | Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers | list(string) | `null` | no |
 | docker_labels | The configuration options to send to the `docker_labels` | map(string) | `null` | no |
-| entrypoint | The entry point that is passed to the container | list(string) | `<list>` | no |
-| environment | The environment variables to pass to the container. This is a list of maps | list(map(string)) | `<list>` | no |
+| entrypoint | The entry point that is passed to the container | list(string) | `null` | no |
+| environment | The environment variables to pass to the container. This is a list of maps | object | `null` | no |
 | essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | bool | `true` | no |
 | firelens_configuration | The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html | object | `null` | no |
-| healthcheck | A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | map(string) | `null` | no |
-| links | List of container names this container can communicate with without port mappings | list(string) | `<list>` | no |
+| healthcheck | A map containing command (string), timeout, interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy), and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | object | `null` | no |
+| links | List of container names this container can communicate with without port mappings | list(string) | `null` | no |
 | log_configuration | Log configuration options to send to a custom log driver for the container. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html | object | `null` | no |
-| mount_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | object | `<list>` | no |
+| mount_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | object | `null` | no |
 | port_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort | object | `<list>` | no |
-| privileged | When this variable is `true`, the container is given elevated privileges on the host container instance (similar to the root user). This parameter is not supported for Windows containers or tasks using the Fargate launch type. Due to how Terraform type casts booleans in json it is required to double quote this value | string | `` | no |
+| privileged | When this variable is `true`, the container is given elevated privileges on the host container instance (similar to the root user). This parameter is not supported for Windows containers or tasks using the Fargate launch type. Due to how Terraform type casts booleans in json it is required to double quote this value | string | `null` | no |
 | readonly_root_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | bool | `false` | no |
 | repository_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a Secrets Manager's secret holding the credentials | map(string) | `null` | no |
-| secrets | The secrets to pass to the container. This is a list of maps | list(map(string)) | `<list>` | no |
+| secrets | The secrets to pass to the container. This is a list of maps | object | `null` | no |
 | stop_timeout | Timeout in seconds between sending SIGTERM and SIGKILL to container | number | `30` | no |
-| system_controls | A list of namespaced kernel parameters to set in the container, mapping to the --sysctl option to docker run. This is a list of maps: { namespace = "", value = ""} | list(map(string)) | `<list>` | no |
-| ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | object | `<list>` | no |
-| user | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group | string | `` | no |
-| volumes_from | A list of VolumesFrom maps which contain "sourceContainer" (name of the container that has the volumes to mount) and "readOnly" (whether the container can write to the volume) | object | `<list>` | no |
-| working_directory | The working directory to run commands inside the container | string | `` | no |
+| system_controls | A list of namespaced kernel parameters to set in the container, mapping to the --sysctl option to docker run. This is a list of maps: { namespace = "", value = ""} | list(map(string)) | `null` | no |
+| ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | object | `null` | no |
+| user | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group | string | `null` | no |
+| volumes_from | A list of VolumesFrom maps which contain "sourceContainer" (name of the container that has the volumes to mount) and "readOnly" (whether the container can write to the volume) | object | `null` | no |
+| working_directory | The working directory to run commands inside the container | string | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| json | JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition |
+| json | JSON encoded list of container definitions for use with other terraform resources such as aws_ecs_task_definition |
 | json_map | JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -24,7 +24,8 @@
 | readonly_root_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | bool | `false` | no |
 | repository_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a Secrets Manager's secret holding the credentials | map(string) | `null` | no |
 | secrets | The secrets to pass to the container. This is a list of maps | object | `null` | no |
-| stop_timeout | Timeout in seconds between sending SIGTERM and SIGKILL to container | number | `30` | no |
+| start_timeout | Time duration (in seconds) to wait before giving up on resolving dependencies for a container | number | `30` | no |
+| stop_timeout | Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own | number | `30` | no |
 | system_controls | A list of namespaced kernel parameters to set in the container, mapping to the --sysctl option to docker run. This is a list of maps: { namespace = "", value = ""} | list(map(string)) | `null` | no |
 | ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | object | `null` | no |
 | user | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group | string | `null` | no |

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -39,3 +39,12 @@ port_mappings = [
     protocol      = "udp"
   }
 ]
+
+log_configuration = {
+  logDriver = "json-file"
+  options = {
+    "max-size" = "10m"
+    "max-file" = "3"
+  }
+  secretOptions = null
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -13,4 +13,5 @@ module "container" {
   readonly_root_filesystem     = var.readonly_root_filesystem
   environment                  = var.environment
   port_mappings                = var.port_mappings
+  log_configuration            = var.log_configuration
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,5 +1,5 @@
 output "json" {
-  description = "Container definition in JSON format"
+  description = "JSON encoded list of container definitions for use with other terraform resources such as aws_ecs_task_definition"
   value       = module.container.json
 }
 

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -44,11 +44,27 @@ variable "essential" {
 }
 
 variable "environment" {
-  type        = list(map(string))
+  type = list(object({
+    name  = string
+    value = string
+  }))
   description = "The environment variables to pass to the container. This is a list of maps"
 }
 
 variable "readonly_root_filesystem" {
   type        = bool
   description = "Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value"
+}
+
+# https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html
+variable "log_configuration" {
+  type = object({
+    logDriver = string
+    options   = map(string)
+    secretOptions = list(object({
+      name      = string
+      valueFrom = string
+    }))
+  })
+  description = "Log configuration options to send to a custom log driver for the container. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html"
 }

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ locals {
     environment            = local.final_environment_vars
     secrets                = var.secrets
     dockerLabels           = var.docker_labels
+    startTimeout           = var.start_timeout
     stopTimeout            = var.stop_timeout
     systemControls         = var.system_controls
   }

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,26 @@
 locals {
+  # Sort environment variables so terraform will not try to recreate on each plan/apply
+  env_vars             = var.environment != null ? var.environment : []
+  env_vars_keys        = [for m in local.env_vars : lookup(m, "name")]
+  env_vars_values      = [for m in local.env_vars : lookup(m, "value")]
+  env_vars_as_map      = zipmap(local.env_vars_keys, local.env_vars_values)
+  sorted_env_vars_keys = sort(local.env_vars_keys)
+
+  sorted_environment_vars = [
+    for key in local.sorted_env_vars_keys :
+    {
+      name  = key
+      value = lookup(local.env_vars_as_map, key)
+    }
+  ]
+
+  # This strange-looking variable is needed because terraform (currently) does not support explicit `null` in ternary operator,
+  # so this does not work: final_environment_vars = length(local.sorted_environment_vars) > 0 ? local.sorted_environment_vars : null
+  null_value = var.environment == null ? var.environment : null
+
+  # https://www.terraform.io/docs/configuration/expressions.html#null
+  final_environment_vars = length(local.sorted_environment_vars) > 0 ? local.sorted_environment_vars : local.null_value
+
   container_definition = {
     name                   = var.container_name
     image                  = var.container_image
@@ -20,91 +42,15 @@ locals {
     healthCheck            = var.healthcheck
     firelensConfiguration  = var.firelens_configuration
     logConfiguration       = var.log_configuration
-
-    memory            = "memory_sentinel_value"
-    memoryReservation = "memory_reservation_sentinel_value"
-    cpu               = "cpu_sentinel_value"
-    environment       = "environment_sentinel_value"
-    secrets           = "secrets_sentinel_value"
-    dockerLabels      = "docker_labels_sentinel_value"
-    stopTimeout       = "stop_timeout_sentinel_value"
-    systemControls    = "system_controls_sentinel_value"
+    memory                 = var.container_memory
+    memoryReservation      = var.container_memory_reservation
+    cpu                    = var.container_cpu
+    environment            = local.final_environment_vars
+    secrets                = var.secrets
+    dockerLabels           = var.docker_labels
+    stopTimeout            = var.stop_timeout
+    systemControls         = var.system_controls
   }
 
-  environment = var.environment
-  secrets     = var.secrets
-}
-
-# The following hacks are required to overcome TF automatic type conversions which lead to issues with the resulting json types.
-# Conversion happens by using the built-in `replace` function in this order:
-#  - Convert `""`, `{}`, `[]`, and `[""]` to `null`
-#  - Convert `"true"` and `"false"` to `true` and `false`
-#  - Convert quoted numbers (e.g. `"123"`) to `123`.
-# Environment variables are kept as strings.
-locals {
-  encoded_environment_variables = jsonencode(local.environment)
-  encoded_secrets               = local.secrets != null && length(local.secrets) > 0 ? jsonencode(local.secrets) : "null"
-  encoded_cpu                   = var.container_cpu > 0 ? var.container_cpu : "null"
-  encoded_memory                = var.container_memory > 0 ? var.container_memory : "null"
-  encoded_memory_reservation    = var.container_memory_reservation > 0 ? var.container_memory_reservation : "null"
-  encoded_stop_timeout          = var.stop_timeout > 0 ? var.stop_timeout : "null"
-  encoded_docker_labels         = var.docker_labels != null ? jsonencode(var.docker_labels) : "null"
-  encoded_system_controls       = length(var.system_controls) > 0 ? jsonencode(var.system_controls) : "null"
-
-  encoded_container_definition = replace(
-    replace(
-      replace(
-        jsonencode(local.container_definition),
-        "/(\\[\\]|\\[\"\"\\]|\"\"|{})/",
-        "null",
-      ),
-      "/\"(true|false)\"/",
-      "$1"
-    ),
-    "/\"(-?[0-9]+\\.?[0-9]*)\"/",
-    "$1"
-  )
-
-  json_with_environment = replace(
-    local.encoded_container_definition,
-    "/\"environment_sentinel_value\"/",
-    local.encoded_environment_variables
-  )
-  json_with_secrets = replace(
-    local.json_with_environment,
-    "/\"secrets_sentinel_value\"/",
-    local.encoded_secrets
-  )
-  json_with_cpu = replace(
-    local.json_with_secrets,
-    "/\"cpu_sentinel_value\"/",
-    local.encoded_cpu
-  )
-  json_with_memory = replace(
-    local.json_with_cpu,
-    "/\"memory_sentinel_value\"/",
-    local.encoded_memory
-  )
-  json_with_memory_reservation = replace(
-    local.json_with_memory,
-    "/\"memory_reservation_sentinel_value\"/",
-    local.encoded_memory_reservation
-  )
-  json_with_stop_timeout = replace(
-    local.json_with_memory_reservation,
-    "/\"stop_timeout_sentinel_value\"/",
-    local.encoded_stop_timeout
-  )
-  json_with_docker_labels = replace(
-    local.json_with_stop_timeout,
-    "/\"docker_labels_sentinel_value\"/",
-    local.encoded_docker_labels
-  )
-  json_with_system_controls = replace(
-    local.json_with_docker_labels,
-    "/\"system_controls_sentinel_value\"/",
-    local.encoded_system_controls
-  )
-
-  json_map = local.json_with_system_controls
+  json_map = jsonencode(local.container_definition)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "json" {
-  description = "JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition"
+  description = "JSON encoded list of container definitions for use with other terraform resources such as aws_ecs_task_definition"
   value       = "[${local.json_map}]"
 }
 

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -33,6 +33,7 @@ func TestExamplesComplete(t *testing.T) {
 	var jsonObject map[string]interface{}
 	err := json.Unmarshal([]byte(jsonMap), &jsonObject)
 	assert.NoError(t, err)
+
 	assert.Equal(t, "app", jsonObject["name"])
 	assert.Equal(t, "cloudposse/geodesic", jsonObject["image"])
 	assert.Equal(t, 256, int((jsonObject["memory"]).(float64)))

--- a/variables.tf
+++ b/variables.tf
@@ -194,9 +194,15 @@ variable "docker_labels" {
   default     = null
 }
 
+variable "start_timeout" {
+  type        = number
+  description = "Time duration (in seconds) to wait before giving up on resolving dependencies for a container"
+  default     = 30
+}
+
 variable "stop_timeout" {
   type        = number
-  description = "Timeout in seconds between sending SIGTERM and SIGKILL to container"
+  description = "Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own"
   default     = 30
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -38,9 +38,16 @@ variable "port_mappings" {
   ]
 }
 
+# https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html
 variable "healthcheck" {
-  type        = map(string)
-  description = "A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries)"
+  type = object({
+    command     = list(string)
+    retries     = number
+    timeout     = number
+    interval    = number
+    startPeriod = number
+  })
+  description = "A map containing command (string), timeout, interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy), and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries)"
   default     = null
 }
 
@@ -59,31 +66,37 @@ variable "essential" {
 variable "entrypoint" {
   type        = list(string)
   description = "The entry point that is passed to the container"
-  default     = [""]
+  default     = null
 }
 
 variable "command" {
   type        = list(string)
   description = "The command that is passed to the container"
-  default     = [""]
+  default     = null
 }
 
 variable "working_directory" {
   type        = string
   description = "The working directory to run commands inside the container"
-  default     = ""
+  default     = null
 }
 
 variable "environment" {
-  type        = list(map(string))
+  type = list(object({
+    name  = string
+    value = string
+  }))
   description = "The environment variables to pass to the container. This is a list of maps"
-  default     = []
+  default     = null
 }
 
 variable "secrets" {
-  type        = list(map(string))
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
   description = "The secrets to pass to the container. This is a list of maps"
-  default     = []
+  default     = null
 }
 
 variable "readonly_root_filesystem" {
@@ -123,13 +136,13 @@ variable "mount_points" {
   }))
 
   description = "Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`"
-  default     = []
+  default     = null
 }
 
 variable "dns_servers" {
   type        = list(string)
   description = "Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers"
-  default     = []
+  default     = null
 }
 
 variable "ulimits" {
@@ -139,7 +152,7 @@ variable "ulimits" {
     softLimit = number
   }))
   description = "Container ulimit settings. This is a list of maps, where each map should contain \"name\", \"hardLimit\" and \"softLimit\""
-  default     = []
+  default     = null
 }
 
 variable "repository_credentials" {
@@ -154,25 +167,25 @@ variable "volumes_from" {
     readOnly        = bool
   }))
   description = "A list of VolumesFrom maps which contain \"sourceContainer\" (name of the container that has the volumes to mount) and \"readOnly\" (whether the container can write to the volume)"
-  default     = []
+  default     = null
 }
 
 variable "links" {
   type        = list(string)
   description = "List of container names this container can communicate with without port mappings"
-  default     = []
+  default     = null
 }
 
 variable "user" {
   type        = string
   description = "The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group"
-  default     = ""
+  default     = null
 }
 
 variable "container_depends_on" {
   type        = list(string)
   description = "The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed"
-  default     = []
+  default     = null
 }
 
 variable "docker_labels" {
@@ -190,11 +203,11 @@ variable "stop_timeout" {
 variable "privileged" {
   type        = string
   description = "When this variable is `true`, the container is given elevated privileges on the host container instance (similar to the root user). This parameter is not supported for Windows containers or tasks using the Fargate launch type. Due to how Terraform type casts booleans in json it is required to double quote this value"
-  default     = ""
+  default     = null
 }
 
 variable "system_controls" {
   type        = list(map(string))
   description = "A list of namespaced kernel parameters to set in the container, mapping to the --sysctl option to docker run. This is a list of maps: { namespace = \"\", value = \"\"}"
-  default     = []
+  default     = null
 }


### PR DESCRIPTION
## what
* Simplify code using TF 0.12 first-class types and syntax
* Sort provided ENV vars
* Add missing parameters

## why
* No need to convert all `falsy` values into `null` and un-quote booleans and numbers since TF 0.12 has first class types for `bool`, `number` and `object` that can be converted directly to JSON, as well as `null` value which is supported in JSON. So this is not needed:

```
# The following hacks are required to overcome TF automatic type conversions which lead to issues with the resulting json types.
# Conversion happens by using the built-in `replace` function in this order:
#  - Convert `""`, `{}`, `[]`, and `[""]` to `null`
#  - Convert `"true"` and `"false"` to `true` and `false`
#  - Convert quoted numbers (e.g. `"123"`) to `123`.
```

* Sort provided ENV vars so terraform will not attempt to recreate on each plan/apply

## related
* Closes #40 
* Closes #20 
* Closes #33 
* Closes #41 

## test
* `terraform apply` on `examples/complete` produces a valid JSON with sorted ENV vars containing names and values as strings (as required by ECS)

```
json_map = {"command":null,"cpu":256,"dependsOn":null,"dnsServers":null,"dockerLabels":null,"entryPoint":null,"environment":[{"name":"false_boolean_var","value":"false"},{"name":"integer_var","value":"42"},{"name":"string_var","value":"I am a string"},{"name":"true_boolean_var","value":"true"}],"essential":true,"firelensConfiguration":null,"healthCheck":null,"image":"cloudposse/geodesic","links":null,"logConfiguration":{"logDriver":"json-file","options":{"max-file":"3","max-size":"10m"},"secretOptions":null},"memory":256,"memoryReservation":128,"mountPoints":null,"name":"app","portMappings":[{"containerPort":8080,"hostPort":80,"protocol":"tcp"},{"containerPort":8081,"hostPort":443,"protocol":"udp"}],"privileged":null,"readonlyRootFilesystem":false,"repositoryCredentials":null,"secrets":null,"stopTimeout":30,"systemControls":null,"ulimits":null,"user":null,"volumesFrom":null,"workingDirectory":null}
```



