### PR TITLE
Add to mount_points readOnly support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,7 @@ locals {
     user                   = var.user
     dependsOn              = var.container_depends_on
     privileged             = var.privileged
+    networkMode            = var.container_network_mode
     portMappings           = var.port_mappings
     healthCheck            = var.healthcheck
     firelensConfiguration  = var.firelens_configuration

--- a/variables.tf
+++ b/variables.tf
@@ -165,6 +165,7 @@ variable "mount_points" {
   type = list(object({
     containerPath = string
     sourceVolume  = string
+    readOnly      = bool
   }))
 
   description = "Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`"

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,12 @@ variable "container_memory_reservation" {
   default     = 128
 }
 
+variable "container_network_mode" {
+  type = string
+  default = "awsvpc"
+  description = "One of: [none, bridge, awsvpc, host] see hhttps://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#network_mode"
+}
+
 variable "port_mappings" {
   type = list(object({
     containerPort = number


### PR DESCRIPTION
Under mountPoints, readOnly attribute.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definitions

Also requested in https://github.com/cloudposse/terraform-aws-ecs-container-definition/issues/66

This PR breaks every code that uses mount_points attribute. Can't make the readOnly attribute optional. https://github.com/hashicorp/terraform/issues/19898
