### PR TITLE
Add environmentFiles parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Available targets:
 | docker_labels | The configuration options to send to the `docker_labels` | map(string) | `null` | no |
 | entrypoint | The entry point that is passed to the container | list(string) | `null` | no |
 | environment | The environment variables to pass to the container. This is a list of maps | object | `null` | no |
+| environment_files | One or more files containing the environment variables to pass to the container. This maps to the --env-file option to docker run. The file must be hosted in Amazon S3. This option is only available to tasks using the EC2 launch type. This is a list of maps | object | `null` | no |
 | essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | bool | `true` | no |
 | firelens_configuration | The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html | object | `null` | no |
 | healthcheck | A map containing command (string), timeout, interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy), and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | object | `null` | no |
@@ -215,6 +216,10 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 ## Slack Community
 
 Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
+
+## Discourse Forums
+
+Participate in our [Discourse Forums][discourse]. Here you'll find answers to commonly asked questions. Most questions will be related to the enormous number of projects we support on our GitHub. Come here to collaborate on answers, find solutions, and get ideas about the products and services we value. It only takes a minute to get started! Just sign in with SSO using your GitHub account.
 
 ## Newsletter
 
@@ -331,6 +336,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [testimonial]: https://cpco.io/leave-testimonial?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ecs-container-definition&utm_content=testimonial
   [office_hours]: https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ecs-container-definition&utm_content=office_hours
   [newsletter]: https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ecs-container-definition&utm_content=newsletter
+  [discourse]: https://ask.sweetops.com/?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ecs-container-definition&utm_content=discourse
   [email]: https://cpco.io/email?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ecs-container-definition&utm_content=email
   [commercial_support]: https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ecs-container-definition&utm_content=commercial_support
   [we_love_open_source]: https://cpco.io/we-love-open-source?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ecs-container-definition&utm_content=we_love_open_source

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -13,6 +13,7 @@
 | docker_labels | The configuration options to send to the `docker_labels` | map(string) | `null` | no |
 | entrypoint | The entry point that is passed to the container | list(string) | `null` | no |
 | environment | The environment variables to pass to the container. This is a list of maps | object | `null` | no |
+| environment_files | One or more files containing the environment variables to pass to the container. This maps to the --env-file option to docker run. The file must be hosted in Amazon S3. This option is only available to tasks using the EC2 launch type. This is a list of maps | object | `null` | no |
 | essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | bool | `true` | no |
 | firelens_configuration | The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html | object | `null` | no |
 | healthcheck | A map containing command (string), timeout, interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy), and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | object | `null` | no |

--- a/examples/env_vars_files/main.tf
+++ b/examples/env_vars_files/main.tf
@@ -1,0 +1,21 @@
+module "container" {
+  source          = "../../"
+  container_name  = "name"
+  container_image = "cloudposse/geodesic"
+
+  environment_files = [
+    {
+      type  = "s3"
+      value = "arn:aws:s3:::s3_bucket_name/envfile_01.env"
+    },
+    {
+      type  = "s3"
+      value = "arn:aws:s3:::s3_bucket_name/another_envfile.env"
+    }
+  ]
+}
+
+output "json" {
+  description = "Container definition in JSON format"
+  value       = module.container.json_map
+}

--- a/examples/env_vars_files/main.tf
+++ b/examples/env_vars_files/main.tf
@@ -5,12 +5,12 @@ module "container" {
 
   environment_files = [
     {
-      type  = "s3"
       value = "arn:aws:s3:::s3_bucket_name/envfile_01.env"
+      type  = "s3"
     },
     {
-      type  = "s3"
       value = "arn:aws:s3:::s3_bucket_name/another_envfile.env"
+      type  = "s3"
     }
   ]
 }

--- a/examples/env_vars_files/versions.tf
+++ b/examples/env_vars_files/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12.0"
+
+  required_providers {
+    local = "~> 1.2"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,7 @@ locals {
     memoryReservation      = var.container_memory_reservation
     cpu                    = var.container_cpu
     environment            = local.final_environment_vars
+    environmentFiles       = var.environment_files
     secrets                = var.secrets
     dockerLabels           = var.docker_labels
     startTimeout           = var.start_timeout

--- a/variables.tf
+++ b/variables.tf
@@ -93,8 +93,8 @@ variable "environment" {
 # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_EnvironmentFile.html
 variable "environment_files" {
   type = list(object({
-    type  = string
     value = string
+    type  = string
   }))
   description = "One or more files containing the environment variables to pass to the container. This maps to the --env-file option to docker run. The file must be hosted in Amazon S3. This option is only available to tasks using the EC2 launch type. This is a list of maps"
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -90,6 +90,16 @@ variable "environment" {
   default     = null
 }
 
+# https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_EnvironmentFile.html
+variable "environment_files" {
+  type = list(object({
+    type  = string
+    value = string
+  }))
+  description = "One or more files containing the environment variables to pass to the container. This maps to the --env-file option to docker run. The file must be hosted in Amazon S3. This option is only available to tasks using the EC2 launch type. This is a list of maps"
+  default     = null
+}
+
 variable "secrets" {
   type = list(object({
     name      = string


### PR DESCRIPTION
AWS announced that ECS supports environment files for the EC2 launch type:
https://aws.amazon.com/about-aws/whats-new/2020/05/amazon-elastic-container-service-supports-environment-files-ec2-launch-type/

This PR adds the new `environmentFiles` parameter to the container definition.

I've included a basic example of how this is used in `examples/env_vars_files`.