### PR TITLE
fix: forgot to merge the definition without null

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,5 +69,5 @@ locals {
     k => v
     if v != null
   }
-  json_map = jsonencode(merge(local.container_definition, var.container_definition))
+  json_map = jsonencode(merge(local.container_definition_without_null, var.container_definition))
 }


### PR DESCRIPTION
## what
Previous PR https://github.com/cloudposse/terraform-aws-ecs-container-definition/pull/81 forgot to use `local.container_definition_without_null` when merging

## why
* null is still showing up in the diff

## references
* Closes https://github.com/cloudposse/terraform-aws-ecs-container-definition/issues/80
