### PR TITLE
feat: Added missing keys for container definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -119,9 +120,11 @@ No provider.
 | container\_memory | The amount of memory (in MiB) to allow the container to use. This is a hard limit, if the container attempts to exceed the container\_memory, the container is killed. This field is optional for Fargate launch type and the total amount of container\_memory of all containers in a task will need to be lower than the task memory value | `number` | `null` | no |
 | container\_memory\_reservation | The amount of memory (in MiB) to reserve for the container. If container needs to exceed this threshold, it can do so up to the set container\_memory hard limit | `number` | `null` | no |
 | container\_name | The name of the container. Up to 255 characters ([a-z], [A-Z], [0-9], -, \_ allowed) | `string` | n/a | yes |
+| disable\_networking | When this parameter is true, networking is disabled within the container. | `bool` | `null` | no |
 | dns\_search\_domains | Container DNS search domains. A list of DNS search domains that are presented to the container | `list(string)` | `null` | no |
 | dns\_servers | Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers | `list(string)` | `null` | no |
 | docker\_labels | The configuration options to send to the `docker_labels` | `map(string)` | `null` | no |
+| docker\_security\_options | A list of strings to provide custom labels for SELinux and AppArmor multi-level security systems. | `list(string)` | `null` | no |
 | entrypoint | The entry point that is passed to the container | `list(string)` | `null` | no |
 | environment | The environment variables to pass to the container. This is a list of maps. map\_environment overrides environment | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | environment\_files | One or more files containing the environment variables to pass to the container. This maps to the --env-file option to docker run. The file must be hosted in Amazon S3. This option is only available to tasks using the EC2 launch type. This is a list of maps | <pre>list(object({<br>    value = string<br>    type  = string<br>  }))</pre> | `null` | no |
@@ -129,6 +132,8 @@ No provider.
 | extra\_hosts | A list of hostnames and IP address mappings to append to the /etc/hosts file on the container. This is a list of maps | <pre>list(object({<br>    ipAddress = string<br>    hostname  = string<br>  }))</pre> | `null` | no |
 | firelens\_configuration | The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html | <pre>object({<br>    type    = string<br>    options = map(string)<br>  })</pre> | `null` | no |
 | healthcheck | A map containing command (string), timeout, interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy), and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | <pre>object({<br>    command     = list(string)<br>    retries     = number<br>    timeout     = number<br>    interval    = number<br>    startPeriod = number<br>  })</pre> | `null` | no |
+| hostname | The hostname to use for your container. | `string` | `null` | no |
+| interactive | When this parameter is true, this allows you to deploy containerized applications that require stdin or a tty to be allocated. | `bool` | `null` | no |
 | links | List of container names this container can communicate with without port mappings | `list(string)` | `null` | no |
 | linux\_parameters | Linux-specific modifications that are applied to the container, such as Linux kernel capabilities. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LinuxParameters.html | <pre>object({<br>    capabilities = object({<br>      add  = list(string)<br>      drop = list(string)<br>    })<br>    devices = list(object({<br>      containerPath = string<br>      hostPath      = string<br>      permissions   = list(string)<br>    }))<br>    initProcessEnabled = bool<br>    maxSwap            = number<br>    sharedMemorySize   = number<br>    swappiness         = number<br>    tmpfs = list(object({<br>      containerPath = string<br>      mountOptions  = list(string)<br>      size          = number<br>    }))<br>  })</pre> | `null` | no |
 | log\_configuration | Log configuration options to send to a custom log driver for the container. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html | `any` | `null` | no |
@@ -136,6 +141,7 @@ No provider.
 | mount\_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`. The `readOnly` key is optional. | `list` | `[]` | no |
 | port\_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort | <pre>list(object({<br>    containerPort = number<br>    hostPort      = number<br>    protocol      = string<br>  }))</pre> | `[]` | no |
 | privileged | When this variable is `true`, the container is given elevated privileges on the host container instance (similar to the root user). This parameter is not supported for Windows containers or tasks using the Fargate launch type. | `bool` | `null` | no |
+| pseudo\_terminal | When this parameter is true, a TTY is allocated. | `bool` | `null` | no |
 | readonly\_root\_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | `bool` | `false` | no |
 | repository\_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a Secrets Manager's secret holding the credentials | `map(string)` | `null` | no |
 | secrets | The secrets to pass to the container. This is a list of maps | <pre>list(object({<br>    name      = string<br>    valueFrom = string<br>  }))</pre> | `null` | no |
@@ -155,6 +161,7 @@ No provider.
 | json\_map\_encoded\_list | JSON string encoded list of container definitions for use with other terraform resources such as aws\_ecs\_task\_definition |
 | json\_map\_object | JSON map encoded container definition |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -21,9 +22,11 @@ No provider.
 | container\_memory | The amount of memory (in MiB) to allow the container to use. This is a hard limit, if the container attempts to exceed the container\_memory, the container is killed. This field is optional for Fargate launch type and the total amount of container\_memory of all containers in a task will need to be lower than the task memory value | `number` | `null` | no |
 | container\_memory\_reservation | The amount of memory (in MiB) to reserve for the container. If container needs to exceed this threshold, it can do so up to the set container\_memory hard limit | `number` | `null` | no |
 | container\_name | The name of the container. Up to 255 characters ([a-z], [A-Z], [0-9], -, \_ allowed) | `string` | n/a | yes |
+| disable\_networking | When this parameter is true, networking is disabled within the container. | `bool` | `null` | no |
 | dns\_search\_domains | Container DNS search domains. A list of DNS search domains that are presented to the container | `list(string)` | `null` | no |
 | dns\_servers | Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers | `list(string)` | `null` | no |
 | docker\_labels | The configuration options to send to the `docker_labels` | `map(string)` | `null` | no |
+| docker\_security\_options | A list of strings to provide custom labels for SELinux and AppArmor multi-level security systems. | `list(string)` | `null` | no |
 | entrypoint | The entry point that is passed to the container | `list(string)` | `null` | no |
 | environment | The environment variables to pass to the container. This is a list of maps. map\_environment overrides environment | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | environment\_files | One or more files containing the environment variables to pass to the container. This maps to the --env-file option to docker run. The file must be hosted in Amazon S3. This option is only available to tasks using the EC2 launch type. This is a list of maps | <pre>list(object({<br>    value = string<br>    type  = string<br>  }))</pre> | `null` | no |
@@ -31,6 +34,8 @@ No provider.
 | extra\_hosts | A list of hostnames and IP address mappings to append to the /etc/hosts file on the container. This is a list of maps | <pre>list(object({<br>    ipAddress = string<br>    hostname  = string<br>  }))</pre> | `null` | no |
 | firelens\_configuration | The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html | <pre>object({<br>    type    = string<br>    options = map(string)<br>  })</pre> | `null` | no |
 | healthcheck | A map containing command (string), timeout, interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy), and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | <pre>object({<br>    command     = list(string)<br>    retries     = number<br>    timeout     = number<br>    interval    = number<br>    startPeriod = number<br>  })</pre> | `null` | no |
+| hostname | The hostname to use for your container. | `string` | `null` | no |
+| interactive | When this parameter is true, this allows you to deploy containerized applications that require stdin or a tty to be allocated. | `bool` | `null` | no |
 | links | List of container names this container can communicate with without port mappings | `list(string)` | `null` | no |
 | linux\_parameters | Linux-specific modifications that are applied to the container, such as Linux kernel capabilities. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LinuxParameters.html | <pre>object({<br>    capabilities = object({<br>      add  = list(string)<br>      drop = list(string)<br>    })<br>    devices = list(object({<br>      containerPath = string<br>      hostPath      = string<br>      permissions   = list(string)<br>    }))<br>    initProcessEnabled = bool<br>    maxSwap            = number<br>    sharedMemorySize   = number<br>    swappiness         = number<br>    tmpfs = list(object({<br>      containerPath = string<br>      mountOptions  = list(string)<br>      size          = number<br>    }))<br>  })</pre> | `null` | no |
 | log\_configuration | Log configuration options to send to a custom log driver for the container. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html | `any` | `null` | no |
@@ -38,6 +43,7 @@ No provider.
 | mount\_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`. The `readOnly` key is optional. | `list` | `[]` | no |
 | port\_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort | <pre>list(object({<br>    containerPort = number<br>    hostPort      = number<br>    protocol      = string<br>  }))</pre> | `[]` | no |
 | privileged | When this variable is `true`, the container is given elevated privileges on the host container instance (similar to the root user). This parameter is not supported for Windows containers or tasks using the Fargate launch type. | `bool` | `null` | no |
+| pseudo\_terminal | When this parameter is true, a TTY is allocated. | `bool` | `null` | no |
 | readonly\_root\_filesystem | Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | `bool` | `false` | no |
 | repository\_credentials | Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a Secrets Manager's secret holding the credentials | `map(string)` | `null` | no |
 | secrets | The secrets to pass to the container. This is a list of maps | <pre>list(object({<br>    name      = string<br>    valueFrom = string<br>  }))</pre> | `null` | no |
@@ -57,3 +63,4 @@ No provider.
 | json\_map\_encoded\_list | JSON string encoded list of container definitions for use with other terraform resources such as aws\_ecs\_task\_definition |
 | json\_map\_object | JSON map encoded container definition |
 
+<!-- markdownlint-restore -->

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -56,3 +56,7 @@ extra_hosts = [{
   hostname  = "app.local"
   },
 ]
+
+hostname        = "hostname"
+pseudo_terminal = true
+interactive     = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -16,4 +16,7 @@ module "container" {
   log_configuration            = var.log_configuration
   privileged                   = var.privileged
   extra_hosts                  = var.extra_hosts
+  hostname                     = var.hostname
+  pseudo_terminal              = var.pseudo_terminal
+  interactive                  = var.interactive
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,3 +1,7 @@
+variable "region" {
+  type = string
+}
+
 variable "container_name" {
   type        = string
   description = "The name of the container. Up to 255 characters ([a-z], [A-Z], [0-9], -, _ allowed)"
@@ -86,7 +90,7 @@ variable "environment" {
     name  = string
     value = string
   }))
-  description = "The environment variables to pass to the container. This is a list of maps"
+  description = "The environment variables to pass to the container. This is a list of maps. map_environment overrides environment"
   default     = []
 }
 
@@ -96,6 +100,12 @@ variable "extra_hosts" {
     hostname  = string
   }))
   description = "A list of hostnames and IP address mappings to append to the /etc/hosts file on the container. This is a list of maps"
+  default     = null
+}
+
+variable "map_environment" {
+  type        = map(string)
+  description = "The environment variables to pass to the container. This is a map of string: {key: value}. map_environment overrides environment"
   default     = null
 }
 
@@ -152,7 +162,7 @@ variable "linux_parameters" {
 
 # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html
 variable "log_configuration" {
-  # type        = map
+  type        = any
   description = "Log configuration options to send to a custom log driver for the container. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html"
   default     = null
 }
@@ -177,6 +187,12 @@ variable "mount_points" {
 variable "dns_servers" {
   type        = list(string)
   description = "Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers"
+  default     = null
+}
+
+variable "dns_search_domains" {
+  type        = list(string)
+  description = "Container DNS search domains. A list of DNS search domains that are presented to the container"
   default     = null
 }
 
@@ -213,8 +229,8 @@ variable "links" {
 
 variable "user" {
   type        = string
-  description = "The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group"
-  default     = "0"
+  description = "The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group. The default (null) will use the container's configured `USER` directive or root if not set."
+  default     = null
 }
 
 variable "container_depends_on" {
@@ -253,5 +269,35 @@ variable "privileged" {
 variable "system_controls" {
   type        = list(map(string))
   description = "A list of namespaced kernel parameters to set in the container, mapping to the --sysctl option to docker run. This is a list of maps: { namespace = \"\", value = \"\"}"
+  default     = null
+}
+
+variable "hostname" {
+  type        = string
+  description = "The hostname to use for your container."
+  default     = null
+}
+
+variable "disable_networking" {
+  type        = bool
+  description = "When this parameter is true, networking is disabled within the container."
+  default     = null
+}
+
+variable "interactive" {
+  type        = bool
+  description = "When this parameter is true, this allows you to deploy containerized applications that require stdin or a tty to be allocated."
+  default     = null
+}
+
+variable "pseudo_terminal" {
+  type        = bool
+  description = "When this parameter is true, a TTY is allocated. "
+  default     = null
+}
+
+variable "docker_security_options" {
+  type        = list(string)
+  description = "A list of strings to provide custom labels for SELinux and AppArmor multi-level security systems."
   default     = null
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0, < 0.14"
 
   required_providers {
     local = "~> 1.2"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14"
+  required_version = ">= 0.12.0"
 
   required_providers {
     local = "~> 1.2"

--- a/main.tf
+++ b/main.tf
@@ -80,6 +80,11 @@ locals {
     stopTimeout            = var.stop_timeout
     systemControls         = var.system_controls
     extraHosts             = var.extra_hosts
+    hostname               = var.hostname
+    disableNetworking      = var.disable_networking
+    interactive            = var.interactive
+    preudoTerminal         = var.pseudo_terminal
+    dockerSecurityOptions  = var.docker_security_options
   }
 
   container_definition_without_null = {

--- a/variables.tf
+++ b/variables.tf
@@ -267,3 +267,33 @@ variable "system_controls" {
   description = "A list of namespaced kernel parameters to set in the container, mapping to the --sysctl option to docker run. This is a list of maps: { namespace = \"\", value = \"\"}"
   default     = null
 }
+
+variable "hostname" {
+  type        = string
+  description = "The hostname to use for your container."
+  default     = null
+}
+
+variable "disable_networking" {
+  type        = bool
+  description = "When this parameter is true, networking is disabled within the container."
+  default     = null
+}
+
+variable "interactive" {
+  type        = bool
+  description = "When this parameter is true, this allows you to deploy containerized applications that require stdin or a tty to be allocated."
+  default     = null
+}
+
+variable "pseudo_terminal" {
+  type        = bool
+  description = "When this parameter is true, a TTY is allocated. "
+  default     = null
+}
+
+variable "docker_security_options" {
+  type        = list(string)
+  description = "A list of strings to provide custom labels for SELinux and AppArmor multi-level security systems."
+  default     = null
+}


### PR DESCRIPTION
## what
Added missing keys for container definition:

- hostname
- disableNetworking
- dockerSecurityOptions
- interactive
- pseudoTerminal

## why
These changes should simplify work with this module. People no longer need to use `container_definition` variable to override options.

## references
Closes #86 


