### PR TITLE
0.12 supports null comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -155,6 +156,7 @@ No provider.
 | json\_map\_encoded\_list | JSON string encoded list of container definitions for use with other terraform resources such as aws\_ecs\_task\_definition |
 | json\_map\_object | JSON map encoded container definition |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -57,3 +58,4 @@ No provider.
 | json\_map\_encoded\_list | JSON string encoded list of container definitions for use with other terraform resources such as aws\_ecs\_task\_definition |
 | json\_map\_object | JSON map encoded container definition |
 
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -22,12 +22,8 @@ locals {
     }
   ] : var.mount_points
 
-  # This strange-looking variable is needed because terraform (currently) does not support explicit `null` in ternary operator,
-  # so this does not work: final_environment_vars = length(local.sorted_environment_vars) > 0 ? local.sorted_environment_vars : null
-  null_value = var.environment == null ? var.environment : null
-
   # https://www.terraform.io/docs/configuration/expressions.html#null
-  final_environment_vars = length(local.sorted_environment_vars) > 0 ? local.sorted_environment_vars : local.null_value
+  final_environment_vars = length(local.sorted_environment_vars) > 0 ? local.sorted_environment_vars : null
 
   log_configuration_secret_options = var.log_configuration != null ? lookup(var.log_configuration, "secretOptions", null) : null
   log_configuration_with_null = var.log_configuration == null ? null : {


### PR DESCRIPTION
## what
* removed the null_value code

## why
* Terraform 0.12 supports conditional operations with null value

## references
* https://www.hashicorp.com/blog/terraform-0-12-conditional-operator-improvements

