### PR TITLE
Force user to "0" when firelens is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -155,6 +156,7 @@ No provider.
 | json\_map\_encoded\_list | JSON string encoded list of container definitions for use with other terraform resources such as aws\_ecs\_task\_definition |
 | json\_map\_object | JSON map encoded container definition |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -57,3 +58,4 @@ No provider.
 | json\_map\_encoded\_list | JSON string encoded list of container definitions for use with other terraform resources such as aws\_ecs\_task\_definition |
 | json\_map\_object | JSON map encoded container definition |
 
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ locals {
     if v != null
   }
   user = var.firelens_configuration != null ? "0" : var.user
- 
+
   container_definition = {
     name                   = var.container_name
     image                  = var.container_image

--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,8 @@ locals {
     k => v
     if v != null
   }
-
+  user = var.firelens_configuration != null ? "0" : var.user
+ 
   container_definition = {
     name                   = var.container_name
     image                  = var.container_image
@@ -61,7 +62,7 @@ locals {
     repositoryCredentials  = var.repository_credentials
     links                  = var.links
     volumesFrom            = var.volumes_from
-    user                   = var.user
+    user                   = local.user
     dependsOn              = var.container_depends_on
     privileged             = var.privileged
     portMappings           = var.port_mappings


### PR DESCRIPTION
## what

Firelens tasks must only be configured with `user="0"`

## why

If one submits a firelens-enabled task definition with `user=null`, AWS replaces the value with `"0"`. This causes Terraform to repeatedly try to fix the discrepancy.

                  ~ user                   = "0" -> null

Additionally, attempting to set the `user` to any value _other_ than `"0"` (or null) is an error:

                  ~ user                   = "0" -> "root"
    ...
    Error: ClientException: If 'user' field is specified on firelens container, then 'UID' has to be '0'.

