### PR TITLE
Remove sensitive outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ Available targets:
 
 No provider.
 
+## Modules
+
+No Modules.
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -193,7 +201,6 @@ No provider.
 | json\_map\_encoded | JSON string encoded container definitions for use with other terraform resources such as aws\_ecs\_task\_definition |
 | json\_map\_encoded\_list | JSON string encoded list of container definitions for use with other terraform resources such as aws\_ecs\_task\_definition |
 | json\_map\_object | JSON map encoded container definition |
-
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -10,6 +10,14 @@
 
 No provider.
 
+## Modules
+
+No Modules.
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -63,5 +71,4 @@ No provider.
 | json\_map\_encoded | JSON string encoded container definitions for use with other terraform resources such as aws\_ecs\_task\_definition |
 | json\_map\_encoded\_list | JSON string encoded list of container definitions for use with other terraform resources such as aws\_ecs\_task\_definition |
 | json\_map\_object | JSON map encoded container definition |
-
 <!-- markdownlint-restore -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,17 +1,14 @@
 output "json_map_encoded_list" {
   description = "JSON string encoded list of container definitions for use with other terraform resources such as aws_ecs_task_definition"
   value       = "[${local.json_map}]"
-  sensitive   = true
 }
 
 output "json_map_encoded" {
   description = "JSON string encoded container definitions for use with other terraform resources such as aws_ecs_task_definition"
   value       = local.json_map
-  sensitive   = true
 }
 
 output "json_map_object" {
   description = "JSON map encoded container definition"
   value       = jsondecode(local.json_map)
-  sensitive   = true
 }


### PR DESCRIPTION
## what
Revert `sensitive = true` outputs

## why
Cannot see the difference in task definitions in `terraform plan` due to `sensitive = true`

## references
Revert https://github.com/cloudposse/terraform-aws-ecs-container-definition/pull/118

