### PR TITLE
secrets valueFrom

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ locals {
   # Sort secrets so terraform will not try to recreate on each plan/apply
   secrets_vars        = var.secrets
   secrets_keys        = var.map_secrets != null ? keys(var.map_secrets) : [for m in local.secrets_vars : lookup(m, "name")]
-  secrets_values      = var.map_secrets != null ? values(var.map_secrets) : [for m in local.secrets_vars : lookup(m, "value")]
+  secrets_values      = var.map_secrets != null ? values(var.map_secrets) : [for m in local.secrets_vars : lookup(m, "valueFrom")]
   secrets_as_map      = zipmap(local.secrets_keys, local.secrets_values)
   sorted_secrets_keys = sort(local.secrets_keys)
 


### PR DESCRIPTION
## what
* Fixes an issue in a previous PR https://github.com/cloudposse/terraform-aws-ecs-container-definition/pull/123 where `value` was used instead of `valueFrom` for the `secrets` key

## why
* This fixes a bug in which the `secrets` key will break the module due to the incorrect key

## references
* Closes https://github.com/cloudposse/terraform-aws-ecs-container-definition/issues/125

