### PR TITLE
Use `json_map_encoded` instead of deprecated to `json_map` in examples

### DIFF
--- a/examples/multiple_definitions/main.tf
+++ b/examples/multiple_definitions/main.tf
@@ -49,7 +49,7 @@ output "second_container_json" {
 resource "aws_ecs_task_definition" "task" {
   family = "foo"
   container_definitions = jsonencode([
-    module.first_container.json_map,
-    module.second_container.json_map
+    module.first_container.json_map_encoded,
+    module.second_container.json_map_encoded
   ])
 }


### PR DESCRIPTION
Fix thanks to https://github.com/cloudposse/terraform-aws-ecs-container-definition/pull/131#issuecomment-817907504