### PR TITLE
make outputs non-sensitive for terraform v0.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <!-- markdownlint-disable -->
 # terraform-aws-ecs-container-definition
 
@@ -31,7 +32,6 @@
 
 Terraform module to generate well-formed JSON documents that are passed to the `aws_ecs_task_definition` Terraform resource as [container definitions](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definitions).
 
-
 ---
 
 This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
@@ -56,7 +56,6 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out!
-
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
 
 ## Providers

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -25,7 +25,7 @@ variable "container_memory_reservation" {
 }
 
 variable "container_definition" {
-  type        = map
+  type        = map(any)
   description = "Container definition overrides which allows for extra keys or overriding existing keys."
   default     = {}
 }
@@ -178,7 +178,7 @@ variable "firelens_configuration" {
 }
 
 variable "mount_points" {
-  type = list
+  type = list(any)
 
   description = "Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`. The `readOnly` key is optional."
   default     = []

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,16 +1,16 @@
 output "json_map_encoded_list" {
   description = "JSON string encoded list of container definitions for use with other terraform resources such as aws_ecs_task_definition"
-  value       = "[${local.json_map}]"
+  value       = "[${nonsensitive(local.json_map)}]"
 }
 
 output "json_map_encoded" {
   description = "JSON string encoded container definitions for use with other terraform resources such as aws_ecs_task_definition"
-  value       = local.json_map
+  value       = nonsensitive(local.json_map)
 }
 
 output "json_map_object" {
   description = "JSON map encoded container definition"
-  value       = jsondecode(local.json_map)
+  value       = nonsensitive(jsondecode(local.json_map))
 }
 
 output "sensitive_json_map_encoded_list" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.14.0"
 
   required_providers {
     local = {


### PR DESCRIPTION
## what
* added `nonsensitive()` around all non-sensitive outputs
## why
* terraform v0.15 requires us to do so, otherwise the module can't be used anymore

## references
* [Terraform Documentation](https://www.terraform.io/docs/language/functions/nonsensitive.html)

## caveats
* This requires a version constraint for the terraform provider `>= 0.14.0`


