### PR TITLE
Add quick usage using correct source

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,20 @@ module "container_definition" {
 }
 ```
 
+The output of this module can then be used with one of our other modules.
+
+```hcl
+module "ecs_alb_service_task" {
+  source = "cloudposse/ecs-alb-service-task/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version = "x.x.x"
+
+  # ...
+  container_definition_json = module.container_definition.json_map_encoded_list
+  # ...
+}
+```
+
 
 
 
@@ -370,8 +384,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Sarkis Varozian][sarkis_avatar]][sarkis_homepage]<br/>[Sarkis Varozian][sarkis_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Yonatan Koren][korenyoni_avatar]][korenyoni_homepage]<br/>[Yonatan Koren][korenyoni_homepage] |
-|---|---|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Sarkis Varozian][sarkis_avatar]][sarkis_homepage]<br/>[Sarkis Varozian][sarkis_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Yonatan Koren][korenyoni_avatar]][korenyoni_homepage]<br/>[Yonatan Koren][korenyoni_homepage] | [![RB][nitrocode_avatar]][nitrocode_homepage]<br/>[RB][nitrocode_homepage] |
+|---|---|---|---|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
@@ -384,6 +398,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [goruha_avatar]: https://img.cloudposse.com/150x150/https://github.com/goruha.png
   [korenyoni_homepage]: https://github.com/korenyoni
   [korenyoni_avatar]: https://img.cloudposse.com/150x150/https://github.com/korenyoni.png
+  [nitrocode_homepage]: https://github.com/nitrocode
+  [nitrocode_avatar]: https://img.cloudposse.com/150x150/https://github.com/nitrocode.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ For complete examples, see
 
 For a complete example with automated tests, see [examples/complete](examples/complete) with `bats` and `Terratest` for the example [test](test).
 
+```hcl
+module "container_definition" {
+  source = "cloudposse/ecs-container-definition/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version = "x.x.x"
+
+  container_name  = "geodesic"
+  container_image = "cloudposse/geodesic"
+}
+```
+
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -58,6 +58,18 @@ usage: |-
   - [string env vars](examples/string_env_vars)
 
   For a complete example with automated tests, see [examples/complete](examples/complete) with `bats` and `Terratest` for the example [test](test).
+  
+  ```hcl
+  module "container_definition" {
+    source = "cloudposse/ecs-container-definition/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version = "x.x.x"
+
+    container_name  = "geodesic"
+    container_image = "cloudposse/geodesic"
+  }
+  ```
+
 include:
 - docs/targets.md
 - docs/terraform.md

--- a/README.yaml
+++ b/README.yaml
@@ -72,7 +72,7 @@ usage: |-
   
   The output of this module can then be used with one of our other modules.
   
-  ```
+  ```hcl
   module "ecs_alb_service_task" {
     source = "cloudposse/ecs-alb-service-task/aws"
     # Cloud Posse recommends pinning every module to a specific version

--- a/README.yaml
+++ b/README.yaml
@@ -69,6 +69,20 @@ usage: |-
     container_image = "cloudposse/geodesic"
   }
   ```
+  
+  The output of this module can then be used with one of our other modules.
+  
+  ```
+  module "ecs_alb_service_task" {
+    source = "cloudposse/ecs-alb-service-task/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version = "x.x.x"
+
+    # ...
+    container_definition_json = module.container_definition.json_map_encoded_list
+    # ...
+  }
+  ```
 
 include:
 - docs/targets.md
@@ -84,3 +98,5 @@ contributors:
   github: goruha
 - name: Yonatan Koren
   github: korenyoni
+- name: RB
+  github: nitrocode


### PR DESCRIPTION
## what
* Add quick usage using correct source

## why
* It's difficult to figure out how to source the module correctly without having to look back at the terraform registry. You could look at the examples too but those `source` arguments use relative paths instead of the registry source.

## references
* N/A
